### PR TITLE
feat: opcode POP (gas cost)

### DIFF
--- a/src/codegen/operations.rs
+++ b/src/codegen/operations.rs
@@ -968,7 +968,7 @@ fn codegen_pop<'c, 'r>(
     // Check there's at least 1 element in stack
     let flag = check_stack_has_at_least(context, &start_block, 1)?;
 
-    let gas_flag = consume_gas(context, &start_block, 3)?;
+    let gas_flag = consume_gas(context, &start_block, 2)?;
 
     let condition = start_block
         .append_operation(arith::andi(gas_flag, flag, location))

--- a/src/codegen/operations.rs
+++ b/src/codegen/operations.rs
@@ -968,11 +968,18 @@ fn codegen_pop<'c, 'r>(
     // Check there's at least 1 element in stack
     let flag = check_stack_has_at_least(context, &start_block, 1)?;
 
+    let gas_flag = consume_gas(context, &start_block, 3)?;
+
+    let condition = start_block
+        .append_operation(arith::andi(gas_flag, flag, location))
+        .result(0)?
+        .into();
+
     let ok_block = region.append_block(Block::new(&[]));
 
     start_block.append_operation(cf::cond_br(
         context,
-        flag,
+        condition,
         &ok_block,
         &op_ctx.revert_block,
         &[],

--- a/tests/operations.rs
+++ b/tests/operations.rs
@@ -1080,3 +1080,13 @@ fn exp_with_stack_underflow() {
     let program = vec![Operation::Exp];
     run_program_assert_revert(program);
 }
+
+#[test]
+fn pop_reverts_when_program_runs_out_of_gas() {
+    let mut program: Vec<Operation> = vec![];
+    for _i in 0..1000 {
+        program.push(Operation::Push(BigUint::from(1_u8)));
+        program.push(Operation::Pop);
+    }
+    run_program_assert_revert(program);
+}


### PR DESCRIPTION
Closes #134 
This PR adds gas consumption to the [POP](https://www.evm.codes/#50?fork=cancun) opcode.