### PR TITLE
feat: opcode SAR (gas cost)

### DIFF
--- a/src/codegen/operations.rs
+++ b/src/codegen/operations.rs
@@ -995,12 +995,19 @@ fn codegen_sar<'c, 'r>(
 
     // Check there's enough elements in stack
     let flag = check_stack_has_at_least(context, &start_block, 2)?;
+    // Check there's enough gas
+    let gas_flag = consume_gas(context, &start_block, 3)?;
+
+    let condition = start_block
+        .append_operation(arith::andi(gas_flag, flag, location))
+        .result(0)?
+        .into();
 
     let ok_block = region.append_block(Block::new(&[]));
 
     start_block.append_operation(cf::cond_br(
         context,
-        flag,
+        condition,
         &ok_block,
         &op_ctx.revert_block,
         &[],

--- a/tests/operations.rs
+++ b/tests/operations.rs
@@ -1080,3 +1080,15 @@ fn exp_with_stack_underflow() {
     let program = vec![Operation::Exp];
     run_program_assert_revert(program);
 }
+
+#[test]
+fn sar_reverts_when_program_runs_out_of_gas() {
+    let (value, shift) = (2_u8, 1_u8);
+    let mut program: Vec<Operation> = vec![];
+    for _i in 0..1000 {
+        program.push(Operation::Push(BigUint::from(value)));
+        program.push(Operation::Push(BigUint::from(shift)));
+        program.push(Operation::Sar);
+    }
+    run_program_assert_revert(program);
+}


### PR DESCRIPTION
Closes #145 
This PR implements gas consumption for [SAR](https://www.evm.codes/#1d?fork=cancun) opcode.