### PR TITLE
feat: opcode MOD & MULMOD & ADDMOD (gas cost)

### DIFF
--- a/src/codegen/operations.rs
+++ b/src/codegen/operations.rs
@@ -686,12 +686,17 @@ fn codegen_mod<'c, 'r>(
 
     // Check there's enough elements in stack
     let flag = check_stack_has_at_least(context, &start_block, 2)?;
+    let gas_flag = consume_gas(context, &start_block, 5)?;
+    let condition = start_block
+        .append_operation(arith::andi(gas_flag, flag, location))
+        .result(0)?
+        .into();
 
     let ok_block = region.append_block(Block::new(&[]));
 
     start_block.append_operation(cf::cond_br(
         context,
-        flag,
+        condition,
         &ok_block,
         &op_ctx.revert_block,
         &[],

--- a/src/codegen/operations.rs
+++ b/src/codegen/operations.rs
@@ -847,7 +847,7 @@ fn codegen_mulmod<'c, 'r>(
 
     // Check there's enough elements in stack
     let flag = check_stack_has_at_least(context, &start_block, 3)?;
-    let gas_flag = consume_gas(context, &start_block, 5)?;
+    let gas_flag = consume_gas(context, &start_block, 8)?;
     let condition = start_block
         .append_operation(arith::andi(gas_flag, flag, location))
         .result(0)?

--- a/src/codegen/operations.rs
+++ b/src/codegen/operations.rs
@@ -847,12 +847,17 @@ fn codegen_mulmod<'c, 'r>(
 
     // Check there's enough elements in stack
     let flag = check_stack_has_at_least(context, &start_block, 3)?;
+    let gas_flag = consume_gas(context, &start_block, 5)?;
+    let condition = start_block
+        .append_operation(arith::andi(gas_flag, flag, location))
+        .result(0)?
+        .into();
 
     let ok_block = region.append_block(Block::new(&[]));
 
     start_block.append_operation(cf::cond_br(
         context,
-        flag,
+        condition,
         &ok_block,
         &op_ctx.revert_block,
         &[],

--- a/src/codegen/operations.rs
+++ b/src/codegen/operations.rs
@@ -757,12 +757,17 @@ fn codegen_addmod<'c, 'r>(
 
     // Check there's enough elements in stack
     let flag = check_stack_has_at_least(context, &start_block, 3)?;
+    let gas_flag = consume_gas(context, &start_block, 8)?;
+    let condition = start_block
+        .append_operation(arith::andi(gas_flag, flag, location))
+        .result(0)?
+        .into();
 
     let ok_block = region.append_block(Block::new(&[]));
 
     start_block.append_operation(cf::cond_br(
         context,
-        flag,
+        condition,
         &ok_block,
         &op_ctx.revert_block,
         &[],

--- a/tests/operations.rs
+++ b/tests/operations.rs
@@ -793,6 +793,18 @@ fn mod_with_stack_underflow() {
 }
 
 #[test]
+fn mod_reverts_when_program_runs_out_of_gas() {
+    let (a, b) = (BigUint::from(5_u8), BigUint::from(10_u8));
+    let mut program: Vec<Operation> = vec![];
+    for _ in 0..1000 {
+        program.push(Operation::Push(a.clone()));
+        program.push(Operation::Push(b.clone()));
+        program.push(Operation::Mod);
+    }
+    run_program_assert_revert(program);
+}
+
+#[test]
 fn addmod_with_non_zero_result() {
     let (a, b, den) = (
         BigUint::from(13_u8),

--- a/tests/operations.rs
+++ b/tests/operations.rs
@@ -934,6 +934,18 @@ fn mulmod_with_overflow() {
 }
 
 #[test]
+fn mulmod_reverts_when_program_runs_out_of_gas() {
+    let (a, b) = (BigUint::from(5_u8), BigUint::from(10_u8));
+    let mut program: Vec<Operation> = vec![];
+    for _ in 0..1000 {
+        program.push(Operation::Push(a.clone()));
+        program.push(Operation::Push(b.clone()));
+        program.push(Operation::Mulmod);
+    }
+    run_program_assert_revert(program);
+}
+
+#[test]
 fn test_sgt_positive_greater_than() {
     let a = BigUint::from(2_u8);
     let b = BigUint::from(1_u8);

--- a/tests/operations.rs
+++ b/tests/operations.rs
@@ -855,6 +855,23 @@ fn addmod_with_overflowing_add() {
 }
 
 #[test]
+fn addmod_reverts_when_program_runs_out_of_gas() {
+    let (a, b, den) = (
+        BigUint::from(5_u8),
+        BigUint::from(10_u8),
+        BigUint::from(2_u8),
+    );
+    let mut program: Vec<Operation> = vec![];
+    for _ in 0..1000 {
+        program.push(Operation::Push(den));
+        program.push(Operation::Push(b));
+        program.push(Operation::Push(a));
+        program.push(Operation::Addmod);
+    }
+    run_program_assert_revert(program);
+}
+
+#[test]
 fn test_gt_less_than() {
     let a = BigUint::from(9_u8);
     let b = BigUint::from(8_u8);

--- a/tests/operations.rs
+++ b/tests/operations.rs
@@ -863,9 +863,9 @@ fn addmod_reverts_when_program_runs_out_of_gas() {
     );
     let mut program: Vec<Operation> = vec![];
     for _ in 0..1000 {
-        program.push(Operation::Push(den));
-        program.push(Operation::Push(b));
-        program.push(Operation::Push(a));
+        program.push(Operation::Push(den.clone()));
+        program.push(Operation::Push(b.clone()));
+        program.push(Operation::Push(a.clone()));
         program.push(Operation::Addmod);
     }
     run_program_assert_revert(program);


### PR DESCRIPTION
Closes #157 & #159 & #158

This PR adds gas consumption to this opcodes:
- [MOD](https://www.evm.codes/#06)
- [MULMOD](https://www.evm.codes/#09) opcode.
- [ADDMOD](https://www.evm.codes/#08) opcode.