### PR TITLE
feat: opcode SUB (gas cost)

### DIFF
--- a/src/codegen/operations.rs
+++ b/src/codegen/operations.rs
@@ -548,11 +548,15 @@ fn codegen_sub<'c, 'r>(
     // Check there's enough elements in stack
     let flag = check_stack_has_at_least(context, &start_block, 2)?;
 
+    let gas_flag = consume_gas(context, &start_block, 3)?;
+
+    let ocndition = start_block.append_operation(arith::andi(gas_flag, flag, location));
+
     let ok_block = region.append_block(Block::new(&[]));
 
     start_block.append_operation(cf::cond_br(
         context,
-        flag,
+        condition,
         &ok_block,
         &op_ctx.revert_block,
         &[],


### PR DESCRIPTION
Closes #138 
This PR handles the addition of gas consumetion to the SUB opcode 