### PR TITLE
feat: add executor module

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,0 +1,31 @@
+use melior::ExecutionEngine;
+
+use crate::{
+    constants::MAIN_ENTRYPOINT,
+    module::MLIRModule,
+    syscall::{self, MainFunc, SyscallContext},
+};
+
+pub struct Executor {
+    engine: ExecutionEngine,
+}
+
+impl Executor {
+    pub fn new(module: &MLIRModule) -> Self {
+        let engine = ExecutionEngine::new(module.module(), 0, &[], false);
+        syscall::register_syscalls(&engine);
+        Self { engine }
+    }
+
+    pub fn execute(&self, context: &mut SyscallContext, initial_gas: u64) -> u8 {
+        let main_fn: MainFunc = self.get_main_entrypoint();
+
+        main_fn(context, initial_gas)
+    }
+
+    fn get_main_entrypoint(&self) -> MainFunc {
+        let function_name = format!("_mlir_ciface_{MAIN_ENTRYPOINT}");
+        let fptr = self.engine.lookup(&function_name);
+        unsafe { std::mem::transmute(fptr) }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub mod codegen;
 pub mod constants;
 pub mod context;
 pub mod errors;
+pub mod executor;
 pub mod module;
 pub mod program;
 pub mod syscall;

--- a/tests/operations.rs
+++ b/tests/operations.rs
@@ -1,11 +1,10 @@
 use evm_mlir::{
-    constants::{gas_cost, MAIN_ENTRYPOINT, REVERT_EXIT_CODE},
+    constants::{gas_cost, REVERT_EXIT_CODE},
     context::Context,
     executor::Executor,
     program::{Operation, Program},
     syscall::SyscallContext,
 };
-use melior::ExecutionEngine;
 use num_bigint::{BigInt, BigUint};
 use rstest::rstest;
 use tempfile::NamedTempFile;

--- a/tests/operations.rs
+++ b/tests/operations.rs
@@ -1,8 +1,9 @@
 use evm_mlir::{
     constants::{gas_cost, MAIN_ENTRYPOINT, REVERT_EXIT_CODE},
     context::Context,
+    executor::Executor,
     program::{Operation, Program},
-    syscall::{register_syscalls, MainFunc, SyscallContext},
+    syscall::SyscallContext,
 };
 use melior::ExecutionEngine;
 use num_bigint::{BigInt, BigUint};
@@ -24,16 +25,11 @@ fn run_program_assert_result_with_gas(
         .compile(&program, &output_file)
         .expect("failed to compile program");
 
-    let engine = ExecutionEngine::new(module.module(), 0, &[], false);
-    register_syscalls(&engine);
-
-    let function_name = format!("_mlir_ciface_{MAIN_ENTRYPOINT}");
-    let fptr = engine.lookup(&function_name);
-    let main_fn: MainFunc = unsafe { std::mem::transmute(fptr) };
+    let executor = Executor::new(&module);
 
     let mut context = SyscallContext::default();
 
-    let result = main_fn(&mut context, initial_gas);
+    let result = executor.execute(&mut context, initial_gas);
 
     assert_eq!(result, expected_result);
 }


### PR DESCRIPTION
Create a new module `Executor` that holds the `ExecutionEngine` and allows calling the main entrypoint of the compiled code.