### PR TITLE
Update opcode tests to align with new gas calculation logic

### DIFF
--- a/src/codegen/operations.rs
+++ b/src/codegen/operations.rs
@@ -527,7 +527,7 @@ fn codegen_add<'c, 'r>(
     // Check there's enough elements in stack
     let flag = check_stack_has_at_least(context, &start_block, 2)?;
 
-    let gas_flag = consume_gas(context, &start_block, 3)?;
+    let gas_flag = consume_gas(context, &start_block, gas_cost::ADD)?;
 
     let condition = start_block
         .append_operation(arith::andi(gas_flag, flag, location))
@@ -663,7 +663,7 @@ fn codegen_sdiv<'c, 'r>(
 
     // Check there's enough elements in stack
     let stack_size_flag = check_stack_has_at_least(context, &start_block, 2)?;
-    let gas_flag = consume_gas(context, &start_block, 5)?;
+    let gas_flag = consume_gas(context, &start_block, gas_cost::SDIV)?;
 
     let ok_flag = start_block
         .append_operation(arith::andi(stack_size_flag, gas_flag, location))
@@ -763,7 +763,7 @@ fn codegen_mod<'c, 'r>(
 
     // Check there's enough elements in stack
     let flag = check_stack_has_at_least(context, &start_block, 2)?;
-    let gas_flag = consume_gas(context, &start_block, 5)?;
+    let gas_flag = consume_gas(context, &start_block, gas_cost::MOD)?;
     let condition = start_block
         .append_operation(arith::andi(gas_flag, flag, location))
         .result(0)?
@@ -834,7 +834,7 @@ fn codegen_smod<'c, 'r>(
 
     // Check there's enough elements in stack
     let flag = check_stack_has_at_least(context, &start_block, 2)?;
-    let gas_flag = consume_gas(context, &start_block, 5)?;
+    let gas_flag = consume_gas(context, &start_block, gas_cost::SMOD)?;
     let condition = start_block
         .append_operation(arith::andi(gas_flag, flag, location))
         .result(0)?
@@ -905,7 +905,7 @@ fn codegen_addmod<'c, 'r>(
 
     // Check there's enough elements in stack
     let flag = check_stack_has_at_least(context, &start_block, 3)?;
-    let gas_flag = consume_gas(context, &start_block, 8)?;
+    let gas_flag = consume_gas(context, &start_block, gas_cost::ADDMOD)?;
     let condition = start_block
         .append_operation(arith::andi(gas_flag, flag, location))
         .result(0)?
@@ -1000,7 +1000,7 @@ fn codegen_mulmod<'c, 'r>(
 
     // Check there's enough elements in stack
     let flag = check_stack_has_at_least(context, &start_block, 3)?;
-    let gas_flag = consume_gas(context, &start_block, 8)?;
+    let gas_flag = consume_gas(context, &start_block, gas_cost::MULMOD)?;
     let condition = start_block
         .append_operation(arith::andi(gas_flag, flag, location))
         .result(0)?
@@ -1095,7 +1095,7 @@ fn codegen_xor<'c, 'r>(
     // Check there's enough elements in stack
     let flag = check_stack_has_at_least(context, &start_block, 2)?;
 
-    let gas_flag = consume_gas(context, &start_block, 3)?;
+    let gas_flag = consume_gas(context, &start_block, gas_cost::XOR)?;
 
     let condition = start_block
         .append_operation(arith::andi(gas_flag, flag, location))
@@ -1218,7 +1218,7 @@ fn codegen_pop<'c, 'r>(
     // Check there's at least 1 element in stack
     let flag = check_stack_has_at_least(context, &start_block, 1)?;
 
-    let gas_flag = consume_gas(context, &start_block, 2)?;
+    let gas_flag = consume_gas(context, &start_block, gas_cost::POP)?;
 
     let condition = start_block
         .append_operation(arith::andi(gas_flag, flag, location))
@@ -1253,7 +1253,7 @@ fn codegen_sar<'c, 'r>(
     // Check there's enough elements in stack
     let flag = check_stack_has_at_least(context, &start_block, 2)?;
     // Check there's enough gas
-    let gas_flag = consume_gas(context, &start_block, 3)?;
+    let gas_flag = consume_gas(context, &start_block, gas_cost::SAR)?;
 
     let condition = start_block
         .append_operation(arith::andi(gas_flag, flag, location))

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -21,6 +21,7 @@ pub mod gas_cost {
     pub const MULMOD: i64 = 8;
     pub const SIGNEXTEND: i64 = 5;
     pub const XOR: i64 = 3;
+    pub const SAR: i64 = 3;
     pub const POP: i64 = 2;
     pub const PC: i64 = 2;
     pub const GAS: i64 = 2;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -17,8 +17,11 @@ pub mod gas_cost {
     pub const SDIV: i64 = 5;
     pub const MOD: i64 = 5;
     pub const SMOD: i64 = 5;
+    pub const ADDMOD: i64 = 8;
+    pub const MULMOD: i64 = 8;
     pub const SIGNEXTEND: i64 = 5;
     pub const XOR: i64 = 3;
+    pub const POP: i64 = 2;
     pub const PC: i64 = 2;
     pub const GAS: i64 = 2;
     pub const JUMPDEST: i64 = 1;

--- a/tests/operations.rs
+++ b/tests/operations.rs
@@ -1150,21 +1150,24 @@ fn addmod_with_overflowing_add() {
 }
 
 #[test]
-#[ignore]
 fn addmod_reverts_when_program_runs_out_of_gas() {
     let (a, b, den) = (
         BigUint::from(5_u8),
         BigUint::from(10_u8),
         BigUint::from(2_u8),
     );
-    let mut program: Vec<Operation> = vec![];
-    for _ in 0..1000 {
-        program.push(Operation::Push(den.clone()));
-        program.push(Operation::Push(b.clone()));
-        program.push(Operation::Push(a.clone()));
-        program.push(Operation::Addmod);
-    }
-    run_program_assert_revert(program);
+
+    let program = vec![
+        Operation::Push(den.clone()),
+        Operation::Push(b.clone()),
+        Operation::Push(a.clone()),
+        Operation::Addmod,
+    ];
+
+    let needed_gas = gas_cost::PUSHN * 3 + gas_cost::ADDMOD;
+    let expected_result = ((a + b) % den).try_into().unwrap();
+
+    run_program_assert_gas_exact(program, expected_result, needed_gas as _);
 }
 
 #[test]
@@ -1247,16 +1250,24 @@ fn mulmod_with_overflow() {
 }
 
 #[test]
-#[ignore]
 fn mulmod_reverts_when_program_runs_out_of_gas() {
-    let (a, b) = (BigUint::from(5_u8), BigUint::from(10_u8));
-    let mut program: Vec<Operation> = vec![];
-    for _ in 0..1000 {
-        program.push(Operation::Push(a.clone()));
-        program.push(Operation::Push(b.clone()));
-        program.push(Operation::Mulmod);
-    }
-    run_program_assert_revert(program);
+    let (a, b, den) = (
+        BigUint::from(13_u8),
+        BigUint::from(30_u8),
+        BigUint::from(10_u8),
+    );
+
+    let program = vec![
+        Operation::Push(den.clone()),
+        Operation::Push(b.clone()),
+        Operation::Push(a.clone()),
+        Operation::Mulmod,
+    ];
+
+    let needed_gas = gas_cost::PUSHN * 3 + gas_cost::MULMOD;
+    let expected_result = ((a * b) % den).try_into().unwrap();
+
+    run_program_assert_gas_exact(program, expected_result, needed_gas as _);
 }
 
 #[test]
@@ -1373,14 +1384,13 @@ fn test_lt_stack_underflow() {
 fn test_gas_with_add_should_revert() {
     let x = 1_u8;
 
-    // TODO: update when PUSH costs gas
     let program = vec![
         Operation::Push(BigUint::from(x)),
         Operation::Push(BigUint::from(x)),
         Operation::Add,
     ];
     let expected_result = x + x;
-    let needed_gas = gas_cost::PUSHN + gas_cost::PUSHN + gas_cost::ADD;
+    let needed_gas = gas_cost::PUSHN * 2 + gas_cost::ADD;
     run_program_assert_gas_exact(program, expected_result, needed_gas as _);
 }
 
@@ -1394,7 +1404,6 @@ fn stop() {
 #[test]
 fn push_push_exp() {
     let (a, b) = (BigUint::from(2_u8), BigUint::from(3_u8));
-
     let program = vec![
         Operation::Push(a.clone()),
         Operation::Push(b.clone()),
@@ -1435,19 +1444,15 @@ fn sar_reverts_when_program_runs_out_of_gas() {
 }
 
 #[test]
-#[ignore]
 fn pop_reverts_when_program_runs_out_of_gas() {
-    let expected_result = 1;
-    // TODO: update when push costs gas
-    let program: Vec<Operation> = vec![
+    let expected_result = 33_u8;
+    let program = vec![
         Operation::Push(BigUint::from(expected_result)),
         Operation::Push(BigUint::from(expected_result + 1)),
         Operation::Pop,
     ];
-
-    let needed_gas = 2;
-    run_program_assert_result_with_gas(program.clone(), expected_result, needed_gas);
-    run_program_assert_reverts_with_gas(program, needed_gas - 1);
+    let needed_gas = gas_cost::PUSHN * 2 + gas_cost::POP;
+    run_program_assert_gas_exact(program, expected_result, needed_gas as _);
 }
 
 #[test]
@@ -1504,71 +1509,64 @@ fn signextend_with_stack_underflow() {
 }
 
 #[test]
-#[ignore]
 fn signextend_gas_should_revert() {
     let value = BigUint::from(0x7F_u8);
     let value_bytes_size = BigUint::from(0_u8);
-    let mut program = vec![];
-
-    for _ in 0..200 {
-        program.push(Operation::Push(value.clone()));
-        program.push(Operation::Push(value_bytes_size.clone()));
-        program.push(Operation::SignExtend);
-    }
-
-    run_program_assert_revert(program);
+    let program = vec![
+        Operation::Push(value.clone()),
+        Operation::Push(value_bytes_size.clone()),
+        Operation::SignExtend,
+    ];
+    let expected_result = value.try_into().unwrap();
+    let needed_gas = gas_cost::PUSHN * 2 + gas_cost::SIGNEXTEND;
+    run_program_assert_gas_exact(program, expected_result, needed_gas as _);
 }
 
 #[test]
-#[ignore]
 fn gas_get_starting_value() {
-    //We have to divide the result in order for it to be contained in just one byte, which is
-    //the u8 result size.
-    const GAS_OP_COST: i64 = 2;
-    const PUSH_GAS_COST: i64 = 3;
+    const INITIAL_GAS: i64 = 30;
 
-    let gas_after_op = (999 - GAS_OP_COST - PUSH_GAS_COST) as u64;
-    let denominator = BigUint::from(4_u8);
-    let expected_result = BigUint::from(gas_after_op) / &denominator;
+    let expected_result = (INITIAL_GAS - gas_cost::GAS) as _;
 
     let program = vec![
-        Operation::Push(denominator), // <No collapse>
-        Operation::Gas,               // <No collapse>
-        Operation::Div,               // <No collapse>
+        Operation::Gas, // <No collapse>
     ];
 
-    run_program_assert_result(program, expected_result.try_into().unwrap());
+    run_program_assert_result_with_gas(program, expected_result, INITIAL_GAS as _);
 }
 
 #[test]
-#[ignore]
-fn gas_value_after_add_op() {
-    const ADD_OP_COST: i64 = 3;
-    const PUSH_GAS_COST: i64 = 3;
-    const GAS_OP_COST: i64 = 2;
+fn gas_value_after_operations() {
+    const INITIAL_GAS: i64 = 50;
 
-    let iterations = 50;
-    let expected_result =
-        999 - PUSH_GAS_COST - (ADD_OP_COST + PUSH_GAS_COST) * iterations - GAS_OP_COST;
+    let gas_consumption = gas_cost::PUSHN * 3 + gas_cost::ADD * 2 + gas_cost::GAS;
+    let expected_result = (INITIAL_GAS - gas_consumption) as _;
 
-    let mut program = vec![];
-    program.push(Operation::Push(BigUint::from(1_u8)));
-    for _ in 0..iterations {
-        program.push(Operation::Push(BigUint::from(1_u8)));
-        program.push(Operation::Add);
-    }
+    let program = vec![
+        Operation::Push(BigUint::ZERO), // <No collapse>
+        Operation::Push(BigUint::ZERO), // <No collapse>
+        Operation::Push(BigUint::ZERO), // <No collapse>
+        Operation::Add,                 // <No collapse>
+        Operation::Add,                 // <No collapse>
+        Operation::Gas,                 // <No collapse>
+    ];
 
-    program.push(Operation::Gas);
-
-    run_program_assert_result(program, expected_result as u8);
+    run_program_assert_result_with_gas(program, expected_result, INITIAL_GAS as _);
 }
 
 #[test]
-#[ignore]
 fn gas_without_enough_gas_revert() {
-    let mut program = vec![];
-    for _ in 0..500 {
-        program.push(Operation::Gas);
-    }
-    run_program_assert_revert(program);
+    let gas_consumption = gas_cost::PUSHN * 3 + gas_cost::ADD * 2 + gas_cost::GAS;
+    let expected_result = 0;
+
+    let program = vec![
+        Operation::Push(BigUint::ZERO), // <No collapse>
+        Operation::Push(BigUint::ZERO), // <No collapse>
+        Operation::Push(BigUint::ZERO), // <No collapse>
+        Operation::Add,                 // <No collapse>
+        Operation::Add,                 // <No collapse>
+        Operation::Gas,                 // <No collapse>
+    ];
+
+    run_program_assert_gas_exact(program, expected_result, gas_consumption as _);
 }


### PR DESCRIPTION
Closes #186 #189 
This PR refactors the opcode tests to align with the new gas calculation logic. It also enhances readability and maintainability by replacing gas cost literals with constants.