### PR TITLE
Increase benchmarks precision

### DIFF
--- a/.github/scripts/run-benchmarks.sh
+++ b/.github/scripts/run-benchmarks.sh
@@ -5,7 +5,7 @@ echo "# Benchmarking results" > bench-hyperfine.md
 sudo swapoff -a # Disabling swap memory to reduce noise
 for program in factorial fibonacci;
 do
-    hyperfine -w 5 -r 10 -N --export-markdown "bench-${program}.md" \
+    sudo hyperfine -w 5 -r 10 -N --export-markdown "bench-${program}.md" \
         -n "evm_mlir_${program}" "target/release/evm_mlir_${program} 500000 1000" \
         -n "revm_${program}" "target/release/revm_${program} 500000 1000"
 

--- a/.github/scripts/run-benchmarks.sh
+++ b/.github/scripts/run-benchmarks.sh
@@ -2,7 +2,7 @@
 
 
 echo "# Benchmarking results" > bench-hyperfine.md
-sudo swapoff -a # Disabling swap memory to reduce noice
+sudo swapoff -a # Disabling swap memory to reduce noise
 for program in factorial fibonacci;
 do
     hyperfine -w 5 -r 10 -N --export-markdown "bench-${program}.md" \

--- a/.github/scripts/run-benchmarks.sh
+++ b/.github/scripts/run-benchmarks.sh
@@ -2,9 +2,10 @@
 
 
 echo "# Benchmarking results" > bench-hyperfine.md
+sudo swapoff -a # Disabling swap memory to reduce noice
 for program in factorial fibonacci;
 do
-    hyperfine -w 5 -r 10 -N --export-markdown "bench-${program}.md" \
+    hyperfine -w 5 -r 20 -N --export-markdown "bench-${program}.md" \
         -n "evm_mlir_${program}" "target/release/evm_mlir_${program} 100000 1000" \
         -n "revm_${program}" "target/release/revm_${program} 100000 1000"
 

--- a/.github/scripts/run-benchmarks.sh
+++ b/.github/scripts/run-benchmarks.sh
@@ -5,9 +5,9 @@ echo "# Benchmarking results" > bench-hyperfine.md
 sudo swapoff -a # Disabling swap memory to reduce noice
 for program in factorial fibonacci;
 do
-    hyperfine -w 5 -r 20 -N --export-markdown "bench-${program}.md" \
-        -n "evm_mlir_${program}" "target/release/evm_mlir_${program} 100000 1000" \
-        -n "revm_${program}" "target/release/revm_${program} 100000 1000"
+    hyperfine -w 5 -r 10 -N --export-markdown "bench-${program}.md" \
+        -n "evm_mlir_${program}" "target/release/evm_mlir_${program} 500000 1000" \
+        -n "revm_${program}" "target/release/revm_${program} 500000 1000"
 
     {
         echo "## Benchmark for program \`$program\`"

--- a/.github/scripts/run-benchmarks.sh
+++ b/.github/scripts/run-benchmarks.sh
@@ -5,7 +5,7 @@ echo "# Benchmarking results" > bench-hyperfine.md
 sudo swapoff -a # Disabling swap memory to reduce noise
 for program in factorial fibonacci;
 do
-    sudo hyperfine -w 5 -r 10 -N --export-markdown "bench-${program}.md" \
+    hyperfine -w 5 -r 10 -N --export-markdown "bench-${program}.md" \
         -n "evm_mlir_${program}" "target/release/evm_mlir_${program} 500000 1000" \
         -n "revm_${program}" "target/release/revm_${program} 500000 1000"
 

--- a/bench/revm_comparison/src/lib.rs
+++ b/bench/revm_comparison/src/lib.rs
@@ -19,7 +19,7 @@ pub fn run_with_evm_mlir(program: &str, runs: usize, number_of_iterations: u32) 
     let program = Program::from_bytecode(&bytes);
 
     // This is for intermediate files
-    let output_file = PathBuf::from("output");
+    let output_file = PathBuf::from("/dev/null");
 
     let context = Context::new();
     let module = context

--- a/bench/revm_comparison/src/lib.rs
+++ b/bench/revm_comparison/src/lib.rs
@@ -19,7 +19,7 @@ pub fn run_with_evm_mlir(program: &str, runs: usize, number_of_iterations: u32) 
     let program = Program::from_bytecode(&bytes);
 
     // This is for intermediate files
-    let output_file = PathBuf::from("/dev/null");
+    let output_file = PathBuf::from("/tmp/output");
 
     let context = Context::new();
     let module = context


### PR DESCRIPTION
This PR modifies the benchmarks precision by incrementing `hyperfine` rounds from `10` to `20`.
It also disables memory swap, in order to reduce noise.