### PR TITLE
Allow to optionally set the output files paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,7 +856,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "tempfile",
  "thiserror",
  "walkdir",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ melior = { version = "0.18.4", features = ["ods-dialects"] }
 mlir-sys = "0.2.2"
 num-bigint = "0.4.5"
 sha3 = "0.10.8"
-tempfile = "3.10.1"
 thiserror = "1.0.57"
 ethereum-types = "0.14.1"
 bytes = { version = "1.6.0", features = ["serde"] }

--- a/bench/revm_comparison/src/lib.rs
+++ b/bench/revm_comparison/src/lib.rs
@@ -1,13 +1,18 @@
 use evm_mlir::{
-    context::Context, db::Db, executor::Executor, primitives::Bytes, program::Program,
-    syscall::SyscallContext, Env,
+    context::{Context, ContextConfig},
+    db::Db,
+    executor::Executor,
+    primitives::Bytes,
+    program::Program,
+    syscall::SyscallContext,
+    Env,
 };
 use revm::{
     db::BenchmarkDB,
     primitives::{address, Bytecode, TransactTo},
     Evm,
 };
-use std::{hint::black_box, path::PathBuf};
+use std::hint::black_box;
 
 pub const FIBONACCI_BYTECODE: &str =
     "5f355f60015b8215601a578181019150909160019003916005565b9150505f5260205ff3";
@@ -18,12 +23,10 @@ pub fn run_with_evm_mlir(program: &str, runs: usize, number_of_iterations: u32) 
     let bytes = hex::decode(program).unwrap();
     let program = Program::from_bytecode(&bytes);
 
-    // This is for intermediate files
-    let output_file = PathBuf::from("output");
-
     let context = Context::new();
+    let config = ContextConfig::default();
     let module = context
-        .compile(&program, &output_file)
+        .compile(&program, config)
         .expect("failed to compile program");
 
     let executor = Executor::new(&module, Default::default());

--- a/bench/revm_comparison/src/lib.rs
+++ b/bench/revm_comparison/src/lib.rs
@@ -1,11 +1,6 @@
 use evm_mlir::{
-    context::{Context, ContextConfig},
-    db::Db,
-    executor::Executor,
-    primitives::Bytes,
-    program::Program,
-    syscall::SyscallContext,
-    Env,
+    context::Context, db::Db, executor::Executor, primitives::Bytes, program::Program,
+    syscall::SyscallContext, Env,
 };
 use revm::{
     db::BenchmarkDB,
@@ -24,9 +19,8 @@ pub fn run_with_evm_mlir(program: &str, runs: usize, number_of_iterations: u32) 
     let program = Program::from_bytecode(&bytes);
 
     let context = Context::new();
-    let config = ContextConfig::default();
     let module = context
-        .compile(&program, config)
+        .compile(&program, Default::default())
         .expect("failed to compile program");
 
     let executor = Executor::new(&module, Default::default());

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -7,7 +7,7 @@ use std::{
 
 use crate::module::MLIRModule;
 use crate::program::Program;
-use crate::{context::ContextConfig, errors::CodegenError};
+use crate::{context::Session, errors::CodegenError};
 use llvm_sys::{
     core::{
         LLVMContextCreate, LLVMContextDispose, LLVMDisposeMessage, LLVMDisposeModule,
@@ -35,8 +35,11 @@ pub use pass_manager::run_pass_manager;
 
 pub fn compile(program: &Program, output_file: impl AsRef<Path>) -> Result<PathBuf, CodegenError> {
     let context = Context::new();
-    let config = ContextConfig::new(output_file.as_ref().to_path_buf());
-    let mlir_module = context.compile(program, config)?;
+    let session = Session {
+        raw_mlir_path: Some(output_file.as_ref().to_path_buf()),
+        ..Default::default()
+    };
+    let mlir_module = context.compile(program, session)?;
     compile_to_object(&mlir_module, output_file)
 }
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -35,8 +35,7 @@ pub use pass_manager::run_pass_manager;
 
 pub fn compile(program: &Program, output_file: impl AsRef<Path>) -> Result<PathBuf, CodegenError> {
     let context = Context::new();
-    let mut config = ContextConfig::default();
-    config.output_file = Some(output_file.as_ref().to_path_buf());
+    let config = ContextConfig::new(output_file.as_ref().to_path_buf());
     let mlir_module = context.compile(program, config)?;
     compile_to_object(&mlir_module, output_file)
 }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -5,9 +5,9 @@ use std::{
     ptr::{addr_of_mut, null_mut},
 };
 
-use crate::errors::CodegenError;
 use crate::module::MLIRModule;
 use crate::program::Program;
+use crate::{context::ContextConfig, errors::CodegenError};
 use llvm_sys::{
     core::{
         LLVMContextCreate, LLVMContextDispose, LLVMDisposeMessage, LLVMDisposeModule,
@@ -35,7 +35,9 @@ pub use pass_manager::run_pass_manager;
 
 pub fn compile(program: &Program, output_file: impl AsRef<Path>) -> Result<PathBuf, CodegenError> {
     let context = Context::new();
-    let mlir_module = context.compile(program, &output_file)?;
+    let mut config = ContextConfig::default();
+    config.output_file = Some(output_file.as_ref().to_path_buf());
+    let mlir_module = context.compile(program, config)?;
     compile_to_object(&mlir_module, output_file)
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -63,6 +63,15 @@ pub struct ContextConfig {
     pub after_pass_mlir: bool,
 }
 
+impl ContextConfig {
+    pub fn new(output: PathBuf) -> Self {
+        Self {
+            output_file: Some(output),
+            after_pass_mlir: false,
+        }
+    }
+}
+
 impl Context {
     pub fn new() -> Self {
         let melior_context = initialize_mlir();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,8 +50,7 @@ impl Evm<Db> {
     /// Executes [the configured transaction](Env::tx).
     pub fn transact(&mut self) -> Result<ResultAndState, EVMError> {
         let context = Context::new();
-        let mut config = ContextConfig::default();
-        config.output_file = Some(PathBuf::from("output"));
+        let config = ContextConfig::new(PathBuf::from("output"));
 
         let code_address = match self.env.tx.transact_to {
             TransactTo::Call(code_address) => code_address,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use builder::EvmBuilder;
+use context::ContextConfig;
 use db::{Database, Db};
 use env::TransactTo;
 use executor::{Executor, OptLevel};
@@ -48,9 +49,9 @@ impl<DB: Database + Default> Evm<DB> {
 impl Evm<Db> {
     /// Executes [the configured transaction](Env::tx).
     pub fn transact(&mut self) -> Result<ResultAndState, EVMError> {
-        let output_file = PathBuf::from("output");
-
         let context = Context::new();
+        let mut config = ContextConfig::default();
+        config.output_file = Some(PathBuf::from("output"));
 
         let code_address = match self.env.tx.transact_to {
             TransactTo::Call(code_address) => code_address,
@@ -61,7 +62,7 @@ impl Evm<Db> {
         let program = Program::from_bytecode(&bytecode);
 
         let module = context
-            .compile(&program, &output_file)
+            .compile(&program, config)
             .expect("failed to compile program");
 
         let executor = Executor::new(&module, OptLevel::Aggressive);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,4 @@
-use std::path::PathBuf;
-
 use builder::EvmBuilder;
-use context::ContextConfig;
 use db::{Database, Db};
 use env::TransactTo;
 use executor::{Executor, OptLevel};
@@ -50,8 +47,6 @@ impl Evm<Db> {
     /// Executes [the configured transaction](Env::tx).
     pub fn transact(&mut self) -> Result<ResultAndState, EVMError> {
         let context = Context::new();
-        let config = ContextConfig::new(PathBuf::from("output"));
-
         let code_address = match self.env.tx.transact_to {
             TransactTo::Call(code_address) => code_address,
             TransactTo::Create => unimplemented!(), // TODO: implement creation
@@ -61,7 +56,7 @@ impl Evm<Db> {
         let program = Program::from_bytecode(&bytecode);
 
         let module = context
-            .compile(&program, config)
+            .compile(&program, Default::default())
             .expect("failed to compile program");
 
         let executor = Executor::new(&module, OptLevel::Aggressive);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use evm_mlir::{
-    context::{Context, ContextConfig},
+    context::{Context, Session},
     db::Db,
     env::Env,
     executor::{Executor, OptLevel},
@@ -22,11 +22,14 @@ fn main() {
     let bytecode = std::fs::read(path).expect("Could not read file");
     let program = Program::from_bytecode(&bytecode);
 
-    let config = ContextConfig::new(PathBuf::from("output"));
+    let session = Session {
+        raw_mlir_path: Some(PathBuf::from("output")),
+        ..Default::default()
+    };
 
     let context = Context::new();
     let module = context
-        .compile(&program, config)
+        .compile(&program, session)
         .expect("failed to compile program");
 
     let executor = Executor::new(&module, opt_level);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::path::{PathBuf};
+use std::path::PathBuf;
 
 use evm_mlir::{
     context::{Context, ContextConfig},
@@ -22,8 +22,7 @@ fn main() {
     let bytecode = std::fs::read(path).expect("Could not read file");
     let program = Program::from_bytecode(&bytecode);
 
-    let mut config = ContextConfig::default();
-    config.output_file = Some(PathBuf::from("output"));
+    let config = ContextConfig::new(PathBuf::from("output"));
 
     let context = Context::new();
     let module = context

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
-use std::path::PathBuf;
+use std::path::{PathBuf};
 
 use evm_mlir::{
-    context::Context,
+    context::{Context, ContextConfig},
     db::Db,
     env::Env,
     executor::{Executor, OptLevel},
@@ -22,12 +22,12 @@ fn main() {
     let bytecode = std::fs::read(path).expect("Could not read file");
     let program = Program::from_bytecode(&bytecode);
 
-    // This is for intermediate files
-    let output_file = PathBuf::from("output");
+    let mut config = ContextConfig::default();
+    config.output_file = Some(PathBuf::from("output"));
 
     let context = Context::new();
     let module = context
-        .compile(&program, &output_file)
+        .compile(&program, config)
         .expect("failed to compile program");
 
     let executor = Executor::new(&module, opt_level);

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -15,7 +15,7 @@
 //! [`mlir::declare_syscalls`], which will make the syscall available inside the MLIR code.
 //! Finally, the function can be called from the MLIR code like a normal function (see
 //! [`mlir::write_result_syscall`] for an example).
-use std::{ffi::c_void, path::PathBuf};
+use std::ffi::c_void;
 
 use crate::{
     constants::call_opcode,
@@ -350,16 +350,9 @@ impl<'c> SyscallContext<'c> {
             return call_opcode::REVERT_RETURN_CODE;
         };
         let program = Program::from_bytecode(&bytecode);
-
-        //TODO: REMOVE THIS -> For the moment we don't need the output, so we just write to a
-        //fixed output file.
-        //In the future we will probably fetch the disk to search for the requested contract
-        //bytecode. Then, if it is not present, we will compile it and store it in the disk
-        let output_file = PathBuf::from("output2");
-
         let context = Context::new();
         let module = context
-            .compile(&program, &output_file)
+            .compile(&program, Default::default())
             .expect("failed to compile program");
 
         let executor = Executor::new(&module, OptLevel::Aggressive);

--- a/tests/operations.rs
+++ b/tests/operations.rs
@@ -4,7 +4,7 @@
 //! may not work properly.
 use evm_mlir::{
     constants::gas_cost::{self, log_dynamic_gas_cost},
-    context::Context,
+    context::{Context, ContextConfig},
     db::Db,
     env::Env,
     executor::Executor,
@@ -16,7 +16,6 @@ use evm_mlir::{
 use hex_literal::hex;
 use num_bigint::{BigInt, BigUint};
 use rstest::rstest;
-use tempfile::NamedTempFile;
 
 fn run_program_get_result_with_gas(
     operations: Vec<Operation>,
@@ -24,13 +23,11 @@ fn run_program_get_result_with_gas(
 ) -> ExecutionResult {
     // Insert a return operation at the end of the program to verify top of stack.
     let program = Program::from(operations);
-    let output_file = NamedTempFile::new()
-        .expect("failed to generate tempfile")
-        .into_temp_path();
 
     let context = Context::new();
+    let config = ContextConfig::default();
     let module = context
-        .compile(&program, &output_file)
+        .compile(&program, config)
         .expect("failed to compile program");
 
     let executor = Executor::new(&module, Default::default());

--- a/tests/operations.rs
+++ b/tests/operations.rs
@@ -4,7 +4,7 @@
 //! may not work properly.
 use evm_mlir::{
     constants::gas_cost::{self, log_dynamic_gas_cost},
-    context::{Context, ContextConfig},
+    context::Context,
     db::Db,
     env::Env,
     executor::Executor,
@@ -25,9 +25,8 @@ fn run_program_get_result_with_gas(
     let program = Program::from(operations);
 
     let context = Context::new();
-    let config = ContextConfig::default();
     let module = context
-        .compile(&program, config)
+        .compile(&program, Default::default())
         .expect("failed to compile program");
 
     let executor = Executor::new(&module, Default::default());


### PR DESCRIPTION
### Inspiration

Currently, we are always writing both mlir after-pass and output files to disk. This is probably introducing noise in our benchmarks running on GitHub, which reduces precision by a big margin. This PR adds a new `Session` struct which allows to set up if and where output and intermediate files should be stored.

### Changes

* Added `Session` struct in `src/context.rs`
* Modify `compile()` function from `src/context.rs` to receive a `Session` instead of a output file path.
* Modify calls to `compile()` function to cope with new API.
  * Eliminate output file writing from benchmarks


Closes #319 