### PR TITLE
Fix `SLOAD` and `SSTORE` to read and write from callee address

### DIFF
--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -212,9 +212,11 @@ impl<'c> SyscallContext<'c> {
         };
 
         let mut state = self.db.clone().into_state();
+        let callee_address = self.env.tx.get_address();
 
-        let caller_account = state.entry(self.env.tx.caller).or_default();
-        caller_account
+        state
+            .entry(callee_address)
+            .or_default()
             .storage
             .extend(self.inner_context.journaled_storage.clone());
 
@@ -569,7 +571,7 @@ impl<'c> SyscallContext<'c> {
     }
 
     pub extern "C" fn read_storage(&mut self, stg_key: &U256, stg_value: &mut U256) {
-        let address = self.env.tx.caller;
+        let address = self.env.tx.get_address();
 
         let key = stg_key.to_primitive_u256();
 
@@ -588,6 +590,10 @@ impl<'c> SyscallContext<'c> {
     pub extern "C" fn write_storage(&mut self, stg_key: &U256, stg_value: &mut U256) -> i64 {
         let key = stg_key.to_primitive_u256();
         let value = stg_value.to_primitive_u256();
+        // TODO: Check if this case is ok. Can storage be written on Create?
+        let TransactTo::Call(address) = self.env.tx.transact_to else {
+            return 0;
+        };
 
         // Update the journaled storage and retrieve the previous stored values.
         let (original, current, is_cold) = match self.inner_context.journaled_storage.get_mut(&key)
@@ -602,7 +608,7 @@ impl<'c> SyscallContext<'c> {
                 (slot.original_value, current_value, is_cold)
             }
             None => {
-                let original_value = self.db.read_storage(self.env.tx.caller, key);
+                let original_value = self.db.read_storage(address, key);
                 self.inner_context.journaled_storage.insert(
                     key,
                     EvmStorageSlot {

--- a/tests/evm.rs
+++ b/tests/evm.rs
@@ -1004,9 +1004,8 @@ fn sstore_happy_path() {
         Operation::Sstore,
     ];
 
-    let (mut env, db) = default_env_and_db_setup(operations);
-    let caller_address = Address::from_low_u64_be(41);
-    env.tx.caller = caller_address;
+    let (env, db) = default_env_and_db_setup(operations);
+    let callee_address = env.tx.get_address();
     let mut evm = Evm::new(env, db);
 
     let res = evm.transact().unwrap();
@@ -1014,7 +1013,7 @@ fn sstore_happy_path() {
 
     let stored_value = res
         .state
-        .get(&caller_address)
+        .get(&callee_address)
         .and_then(|account| account.storage.get(&EU256::from(key)))
         .map(|slot| slot.present_value)
         .unwrap_or(EU256::zero());
@@ -1142,34 +1141,21 @@ fn sload_gas_consumption() {
 fn sload_with_valid_key() {
     let key = 80_u8;
     let value = 11_u8;
-    let program = Program::from(vec![
+    let mut operations = vec![
         Operation::Push((1_u8, BigUint::from(key))),
         Operation::Sload,
-        Operation::Push0,
-        Operation::Mstore,
-        Operation::Push((1_u8, BigUint::from(32_u8))),
-        Operation::Push0,
-        Operation::Return,
-    ]);
-    let (address, bytecode) = (
-        Address::from_low_u64_be(40),
-        Bytecode::from(program.to_bytecode()),
-    );
-    let caller_address = Address::from_low_u64_be(41);
-    let mut env = Env::default();
-    env.tx.gas_limit = 999_999;
-    env.tx.transact_to = TransactTo::Call(address);
-    env.tx.caller = caller_address;
-    let db = Db::new().with_bytecode(address, bytecode);
+    ];
+
+    append_return_result_operations(&mut operations);
+
+    let (env, db) = default_env_and_db_setup(operations);
+    let callee_address = env.tx.get_address();
     let mut evm = Evm::new(env, db);
-
     evm.db
-        .write_storage(caller_address, EU256::from(key), EU256::from(value));
-
+        .write_storage(callee_address, EU256::from(key), EU256::from(value));
     let result = evm.transact().unwrap().result;
     assert!(&result.is_success());
     let result = result.output().unwrap().as_ref();
-
     assert_eq!(EU256::from(result), EU256::from(value));
 }
 
@@ -1493,7 +1479,8 @@ fn sstore_gas_cost_on_cold_non_zero_value_to_zero() {
     ];
 
     let (env, mut db) = default_env_and_db_setup(program);
-    db.write_storage(env.tx.caller, EU256::from(key), EU256::from(original_value));
+    let callee = env.tx.get_address();
+    db.write_storage(callee, EU256::from(key), EU256::from(original_value));
 
     run_program_assert_gas_and_refund(env, db, needed_gas as _, used_gas as _, refunded_gas as _);
 }
@@ -1547,7 +1534,8 @@ fn sstore_gas_cost_restore_warm_from_zero() {
     ];
 
     let (env, mut db) = default_env_and_db_setup(program);
-    db.write_storage(env.tx.caller, EU256::from(key), EU256::from(original_value));
+    let callee = env.tx.get_address();
+    db.write_storage(callee, EU256::from(key), EU256::from(original_value));
 
     run_program_assert_gas_and_refund(env, db, needed_gas as _, used_gas as _, refunded_gas as _);
 }
@@ -1575,7 +1563,8 @@ fn sstore_gas_cost_update_warm_from_zero() {
     ];
 
     let (env, mut db) = default_env_and_db_setup(program);
-    db.write_storage(env.tx.caller, EU256::from(key), EU256::from(original_value));
+    let callee = env.tx.get_address();
+    db.write_storage(callee, EU256::from(key), EU256::from(original_value));
 
     run_program_assert_gas_and_refund(env, db, needed_gas as _, used_gas as _, refunded_gas as _);
 }


### PR DESCRIPTION
### Description

Currently, we are using the `env.tx.caller` both in `SSTORE` and in `SLOAD` as the address from where to write or read. Instead, we should make use of the `env.tx.transact_to`

### Changes

* Modify `write_storage` and `read_storage` to make use of `env.tx.transact_to`
* Modify `SyscallContext::get_result` to merge state from callee instead of caller
* Modify `SSTORE` and `SLOAD` tests under `src/env.rs` to cope with changes

Closes #332