### PR TITLE
Start push0 and call stack limit tests

### DIFF
--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -36,7 +36,7 @@ fn get_ignored_groups() -> HashSet<String> {
         "stEIP3860-limitmeterinitcode".into(),
         "stArgsZeroOneBalance".into(),
         "stRevertTest".into(),
-        "eip3855_push0".into(),
+        //"eip3855_push0".into(),
         "eip4844_blobs".into(),
         "stZeroCallsRevert".into(),
         "stSStoreTest".into(),


### PR DESCRIPTION
Closes https://github.com/lambdaclass/evm_mlir/issues/378
Closes https://github.com/lambdaclass/evm_mlir/issues/305
## Summary
This PR try to add a call depth stack limit to prevent infinite recursion
