### PR TITLE
Ef tests fix

### DIFF
--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -56,9 +56,9 @@ fn get_ignored_groups() -> HashSet<String> {
         "stTransitionTest".into(),
         "stCreate2".into(),
         "stSpecialTest".into(),
-        "stSLoadTest".into(),           //
-        "stRecursiveCreate".into(),     //
-        "vmIOandFlowOperations".into(), //
+        "stSLoadTest".into(),
+        "stRecursiveCreate".into(),
+        "vmIOandFlowOperations".into(),
         "stEIP150Specific".into(),
         "stExtCodeHash".into(),
         "stCallCodes".into(),
@@ -204,11 +204,12 @@ fn run_test(path: &Path, contents: String) -> datatest_stable::Result<()> {
             let mut result_state = HashMap::new();
             for address in test.post_state.keys() {
                 let account = res.state.get(address).unwrap();
+                let opcodes = convert_to_hex(account.info.code.clone().unwrap());
                 result_state.insert(
                     address.to_owned(),
                     AccountInfo {
                         balance: account.info.balance,
-                        code: account.info.code.clone().unwrap(),
+                        code: opcodes,
                         nonce: account.info.nonce,
                         storage: account
                             .storage

--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -181,7 +181,7 @@ fn run_test(path: &Path, contents: String) -> datatest_stable::Result<()> {
             // Load pre storage into db
             for (address, account_info) in unit.pre.iter() {
                 let opcodes = convert_to_hex(account_info.code.clone());
-                db = db.with_contract(address.to_owned(), Bytes::from(opcodes));
+                db = db.with_contract(address.to_owned(), opcodes);
                 db.set_account(
                     address.to_owned(),
                     account_info.nonce,

--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -34,6 +34,7 @@ fn get_ignored_groups() -> HashSet<String> {
         "stEIP5656-MCOPY".into(),
         "stEIP3651-warmcoinbase".into(),
         "stArgsZeroOneBalance".into(),
+        "stTimeConsuming".into(),
         "stRevertTest".into(),
         "eip3855_push0".into(),
         "eip4844_blobs".into(),

--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -50,10 +50,8 @@ fn get_ignored_groups() -> HashSet<String> {
         "stCallCreateCallCodeTest".into(),
         "stPreCompiledContracts2".into(),
         "stZeroKnowledge2".into(),
-        //"stDelegatecallTestHomestead".into(),
-        "stTimeConsuming".into(), //works!
+        "stDelegatecallTestHomestead".into(),
         "stEIP150singleCodeGasPrices".into(),
-        "stTransitionTest".into(), // works!
         "stCreate2".into(),
         "stSpecialTest".into(),
         "stSLoadTest".into(),
@@ -80,7 +78,6 @@ fn get_ignored_groups() -> HashSet<String> {
         "stPreCompiledContracts".into(),
         "stNonZeroCallsTest".into(),
         "stMemoryTest".into(),
-        "stWalletTest".into(), //works!
         "stRandom".into(),
         "stInitCodeTest".into(),
         "stBadOpcode".into(),
@@ -89,12 +86,8 @@ fn get_ignored_groups() -> HashSet<String> {
         "stCallDelegateCodesCallCodeHomestead".into(),
         "yul".into(),
         "stEIP3607".into(),
-        "stEIP3860-limitmeterinitcode".into(), //WORKS! but takes a long time
-        "eip7516_blobgasfee".into(),           //WORKS! but takes a long time
-        "stSelfBalance".into(),                //WORKS! but takes a long time
         "stCreateTest".into(),
         "eip198_modexp_precompile".into(),
-        "stCodeSizeLimit".into(), //works!
         "stRefundTest".into(),
         "stZeroCallsTest".into(),
         "stAttackTest".into(),

--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -50,10 +50,10 @@ fn get_ignored_groups() -> HashSet<String> {
         "stCallCreateCallCodeTest".into(),
         "stPreCompiledContracts2".into(),
         "stZeroKnowledge2".into(),
-        "stDelegatecallTestHomestead".into(),
-        "stTimeConsuming".into(),
+        //"stDelegatecallTestHomestead".into(),
+        "stTimeConsuming".into(), //works!
         "stEIP150singleCodeGasPrices".into(),
-        "stTransitionTest".into(),
+        "stTransitionTest".into(), // works!
         "stCreate2".into(),
         "stSpecialTest".into(),
         "stSLoadTest".into(),
@@ -80,7 +80,7 @@ fn get_ignored_groups() -> HashSet<String> {
         "stPreCompiledContracts".into(),
         "stNonZeroCallsTest".into(),
         "stMemoryTest".into(),
-        "stWalletTest".into(),
+        "stWalletTest".into(), //works!
         "stRandom".into(),
         "stInitCodeTest".into(),
         "stBadOpcode".into(),
@@ -89,9 +89,12 @@ fn get_ignored_groups() -> HashSet<String> {
         "stCallDelegateCodesCallCodeHomestead".into(),
         "yul".into(),
         "stEIP3607".into(),
+        "stEIP3860-limitmeterinitcode".into(), //WORKS! but takes a long time
+        "eip7516_blobgasfee".into(),           //WORKS! but takes a long time
+        "stSelfBalance".into(),                //WORKS! but takes a long time
         "stCreateTest".into(),
         "eip198_modexp_precompile".into(),
-        "stCodeSizeLimit".into(),
+        "stCodeSizeLimit".into(), //works!
         "stRefundTest".into(),
         "stZeroCallsTest".into(),
         "stAttackTest".into(),


### PR DESCRIPTION
Closes https://github.com/lambdaclass/evm_mlir/issues/381
## Summary
This PR fix an issue with the parsing of the code from the EF
## Changes
- Added a function to parse from the hexadecimal string to the hexadecimal value
- Deleted from ignored groups all workings tests
- Added tests that started to fail
- Can tests code without a `to` address