### PR TITLE
Fix env data tests

### DIFF
--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -379,7 +379,7 @@ impl<'c> SyscallContext<'c> {
                         .set_balance(&callee_address, callee_balance + value);
                 }
 
-                let remaining_gas = available_gas.checked_sub(*consumed_gas).unwrap_or(0);
+                let remaining_gas = available_gas.saturating_sub(*consumed_gas);
                 gas_to_send = std::cmp::min(
                     remaining_gas / call_opcode::GAS_CAP_DIVISION_FACTOR,
                     gas_to_send,
@@ -694,7 +694,8 @@ impl<'c> SyscallContext<'c> {
         if gas_refund > 0 {
             self.inner_context.gas_refund += gas_refund as u64;
         } else {
-            self.inner_context
+            self.inner_context.gas_refund = self
+                .inner_context
                 .gas_refund
                 .checked_sub(gas_refund.unsigned_abs())
                 .unwrap_or(0);

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -694,7 +694,10 @@ impl<'c> SyscallContext<'c> {
         if gas_refund > 0 {
             self.inner_context.gas_refund += gas_refund as u64;
         } else {
-            self.inner_context.gas_refund -= gas_refund.unsigned_abs();
+            self.inner_context
+                .gas_refund
+                .checked_sub(gas_refund.unsigned_abs())
+                .unwrap_or(0);
         };
 
         gas_cost

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -379,7 +379,7 @@ impl<'c> SyscallContext<'c> {
                         .set_balance(&callee_address, callee_balance + value);
                 }
 
-                let remaining_gas = available_gas.saturating_sub(*consumed_gas);
+                let remaining_gas = available_gas.checked_sub(*consumed_gas).unwrap_or(0);
                 gas_to_send = std::cmp::min(
                     remaining_gas / call_opcode::GAS_CAP_DIVISION_FACTOR,
                     gas_to_send,

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -379,7 +379,7 @@ impl<'c> SyscallContext<'c> {
                         .set_balance(&callee_address, callee_balance + value);
                 }
 
-                let remaining_gas = available_gas - *consumed_gas;
+                let remaining_gas = available_gas.saturating_sub(*consumed_gas);
                 gas_to_send = std::cmp::min(
                     remaining_gas / call_opcode::GAS_CAP_DIVISION_FACTOR,
                     gas_to_send,

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -697,8 +697,7 @@ impl<'c> SyscallContext<'c> {
             self.inner_context.gas_refund = self
                 .inner_context
                 .gas_refund
-                .checked_sub(gas_refund.unsigned_abs())
-                .unwrap_or(0);
+                .saturating_sub(gas_refund.unsigned_abs());
         };
 
         gas_cost

--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -3,6 +3,7 @@ use std::{
     path::Path,
 };
 mod ef_tests_executor;
+use bytes::Bytes;
 use ef_tests_executor::models::{AccountInfo, TestSuite};
 use evm_mlir::{db::Db, env::TransactTo, Env, Evm};
 
@@ -31,10 +32,9 @@ fn get_ignored_groups() -> HashSet<String> {
     HashSet::from([
         "stEIP4844-blobtransactions".into(),
         "stEIP5656-MCOPY".into(),
-        "stEIP1153-transientStorage".into(),
         "stEIP3651-warmcoinbase".into(),
-        "stEIP3860-limitmeterinitcode".into(),
         "stArgsZeroOneBalance".into(),
+        "stTimeConsuming".into(),
         "stRevertTest".into(),
         "eip3855_push0".into(),
         "eip4844_blobs".into(),
@@ -52,28 +52,24 @@ fn get_ignored_groups() -> HashSet<String> {
         "stPreCompiledContracts2".into(),
         "stZeroKnowledge2".into(),
         "stDelegatecallTestHomestead".into(),
-        "stTimeConsuming".into(),
         "stEIP150singleCodeGasPrices".into(),
-        "stTransitionTest".into(),
         "stCreate2".into(),
         "stSpecialTest".into(),
+        "stSLoadTest".into(),
+        "stRecursiveCreate".into(),
+        "vmIOandFlowOperations".into(),
         "stEIP150Specific".into(),
-        "eip3651_warm_coinbase".into(),
         "stExtCodeHash".into(),
         "stCallCodes".into(),
         "stRandom2".into(),
         "stMemoryStressTest".into(),
         "stStaticFlagEnabled".into(),
         "vmTests".into(),
-        "opcodes".into(),
         "stEIP158Specific".into(),
         "stZeroKnowledge".into(),
-        "stShift".into(),
         "stLogTests".into(),
-        "eip7516_blobgasfee".into(),
         "stBugs".into(),
         "stEIP1559".into(),
-        "stSelfBalance".into(),
         "stStaticCall".into(),
         "stCallDelegateCodesHomestead".into(),
         "stMemExpandingEIP150Calls".into(),
@@ -82,10 +78,7 @@ fn get_ignored_groups() -> HashSet<String> {
         "stCodeCopyTest".into(),
         "stPreCompiledContracts".into(),
         "stNonZeroCallsTest".into(),
-        "stChainId".into(),
-        "vmLogTest".into(),
         "stMemoryTest".into(),
-        "stWalletTest".into(),
         "stRandom".into(),
         "stInitCodeTest".into(),
         "stBadOpcode".into(),
@@ -96,7 +89,6 @@ fn get_ignored_groups() -> HashSet<String> {
         "stEIP3607".into(),
         "stCreateTest".into(),
         "eip198_modexp_precompile".into(),
-        "stCodeSizeLimit".into(),
         "stRefundTest".into(),
         "stZeroCallsTest".into(),
         "stAttackTest".into(),
@@ -112,6 +104,17 @@ fn get_ignored_suites() -> HashSet<String> {
         "ValueOverflow".into(),      // TODO: parse bigint tx value
         "ValueOverflowParis".into(), // TODO: parse bigint tx value
     ])
+}
+
+fn convert_to_hex(account_info_code: Bytes) -> Bytes {
+    let hex_string = std::str::from_utf8(&account_info_code[2..]).unwrap(); // we don't need the 0x
+    let mut opcodes = Vec::new();
+    for i in (0..hex_string.len()).step_by(2) {
+        let pair = &hex_string[i..i + 2];
+        let value = u8::from_str_radix(pair, 16).unwrap();
+        opcodes.push(value);
+    }
+    Bytes::from(opcodes)
 }
 
 fn run_test(path: &Path, contents: String) -> datatest_stable::Result<()> {
@@ -134,18 +137,17 @@ fn run_test(path: &Path, contents: String) -> datatest_stable::Result<()> {
         let Some(tests) = unit.post.get("Cancun") else {
             continue;
         };
-        let Some(to) = unit.transaction.to else {
-            return Err("`to` field is None".into());
+        let to = match unit.transaction.to {
+            Some(to) => TransactTo::Call(to),
+            None => TransactTo::Create,
         };
-        let Some(account) = unit.pre.get(&to) else {
-            return Err("Callee doesn't exist".into());
-        };
+
         let sender = unit.transaction.sender.unwrap_or_default();
         let gas_price = unit.transaction.gas_price.unwrap_or_default();
 
         for test in tests {
             let mut env = Env::default();
-            env.tx.transact_to = TransactTo::Call(to);
+            env.tx.transact_to = to.clone();
             env.tx.gas_price = gas_price;
             env.tx.caller = sender;
             env.tx.gas_limit = unit.transaction.gas_limit[test.indexes.gas].as_u64();
@@ -165,11 +167,22 @@ fn run_test(path: &Path, contents: String) -> datatest_stable::Result<()> {
             if let Some(basefee) = unit.env.current_base_fee {
                 env.block.basefee = basefee;
             };
-            let mut db = Db::new().with_contract(to, account.code.clone());
+            let mut db = match to.clone() {
+                TransactTo::Call(to) => {
+                    let opcodes = convert_to_hex(unit.pre.get(&to).unwrap().code.clone());
+                    Db::new().with_contract(to, opcodes)
+                }
+                TransactTo::Create => {
+                    let opcodes =
+                        convert_to_hex(unit.pre.get(&env.tx.caller).unwrap().code.clone());
+                    Db::new().with_contract(env.tx.get_address(), opcodes)
+                }
+            };
 
             // Load pre storage into db
             for (address, account_info) in unit.pre.iter() {
-                db = db.with_contract(address.to_owned(), account_info.code.clone());
+                let opcodes = convert_to_hex(account_info.code.clone());
+                db = db.with_contract(address.to_owned(), opcodes);
                 db.set_account(
                     address.to_owned(),
                     account_info.nonce,
@@ -196,11 +209,12 @@ fn run_test(path: &Path, contents: String) -> datatest_stable::Result<()> {
             let mut result_state = HashMap::new();
             for address in test.post_state.keys() {
                 let account = res.state.get(address).unwrap();
+                let opcodes = convert_to_hex(account.info.code.clone().unwrap());
                 result_state.insert(
                     address.to_owned(),
                     AccountInfo {
                         balance: account.info.balance,
-                        code: account.info.code.clone().unwrap(),
+                        code: opcodes,
                         nonce: account.info.nonce,
                         storage: account
                             .storage

--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -5,7 +5,7 @@ use std::{
 mod ef_tests_executor;
 use bytes::Bytes;
 use ef_tests_executor::models::{AccountInfo, TestSuite};
-use evm_mlir::{db::Db, env::TransactTo, Env, Evm};
+use evm_mlir::{db::Db, env::TransactTo, result::ExecutionResult, Env, Evm};
 
 fn get_group_name_from_path(path: &Path) -> String {
     // Gets the parent directory's name.
@@ -207,12 +207,6 @@ fn run_test(path: &Path, contents: String) -> datatest_stable::Result<()> {
                     return Ok(()); //Halt and want an error
                 }
                 _ => {}
-            }
-
-            if test.expect_exception.is_some() {
-                assert!(!res.result.is_success());
-                // NOTE: the expect_exception string is an error description, we don't check the expected error
-                continue;
             }
 
             // TODO: use rlp and hash to check logs

--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -96,6 +96,10 @@ fn get_ignored_groups() -> HashSet<String> {
         "stExample".into(),
         "vmArithmeticTest".into(),
         "stQuadraticComplexityTest".into(),
+        "stSelfBalance".into(),
+        "stEIP3855-push0".into(),
+        "stWalletTest".into(),
+        "vmLogTest".into(),
     ])
 }
 
@@ -152,7 +156,7 @@ fn run_test(path: &Path, contents: String) -> datatest_stable::Result<()> {
             env.tx.caller = sender;
             env.tx.gas_limit = unit.transaction.gas_limit[test.indexes.gas].as_u64();
             env.tx.value = unit.transaction.value[test.indexes.value];
-            env.tx.data = unit.transaction.data[test.indexes.data].clone();
+            env.tx.data = convert_to_hex((unit.transaction.data[test.indexes.data].clone()));
 
             env.block.number = unit.env.current_number;
             env.block.coinbase = unit.env.current_coinbase;

--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -55,7 +55,7 @@ fn get_ignored_groups() -> HashSet<String> {
         "stEIP150singleCodeGasPrices".into(),
         "stCreate2".into(),
         "stSpecialTest".into(),
-        //"stSLoadTest".into(),NOW THIS WORKS!
+        "stSLoadTest".into(), //works
         "stRecursiveCreate".into(),
         "vmIOandFlowOperations".into(),
         "stEIP150Specific".into(),
@@ -71,7 +71,7 @@ fn get_ignored_groups() -> HashSet<String> {
         "stBugs".into(),
         "stEIP1559".into(),
         "stStaticCall".into(),
-        "stCallDelegateCodesHomestead".into(),
+        "stCallDelegateCodesHomestead".into(), // works
         "stMemExpandingEIP150Calls".into(),
         "stTransactionTest".into(),
         "eip3860_initcode".into(),
@@ -84,7 +84,7 @@ fn get_ignored_groups() -> HashSet<String> {
         "stBadOpcode".into(),
         "eip1153_tstore".into(),
         "stSolidityTest".into(),
-        //"stCallDelegateCodesCallCodeHomestead".into(), works
+        "stCallDelegateCodesCallCodeHomestead".into(), //works
         "yul".into(),
         "stEIP3607".into(),
         "stCreateTest".into(),

--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -198,10 +198,7 @@ fn run_test(path: &Path, contents: String) -> datatest_stable::Result<()> {
 
             match (&test.expect_exception, &res.result) {
                 (None, _) => {
-                    if let Some((expected_output, output)) =
-                        unit.out.as_ref().zip(res.result.output())
-                    {
-                        if expected_output != output {
+                    if unit.out.as_ref() != res.result.output() {
                             return Err("Wrong output".into());
                         }
                     }

--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -55,7 +55,7 @@ fn get_ignored_groups() -> HashSet<String> {
         "stEIP150singleCodeGasPrices".into(),
         "stCreate2".into(),
         "stSpecialTest".into(),
-        "stSLoadTest".into(),
+        //"stSLoadTest".into(),NOW THIS WORKS!
         "stRecursiveCreate".into(),
         "vmIOandFlowOperations".into(),
         "stEIP150Specific".into(),
@@ -84,7 +84,7 @@ fn get_ignored_groups() -> HashSet<String> {
         "stBadOpcode".into(),
         "eip1153_tstore".into(),
         "stSolidityTest".into(),
-        "stCallDelegateCodesCallCodeHomestead".into(),
+        //"stCallDelegateCodesCallCodeHomestead".into(), works
         "yul".into(),
         "stEIP3607".into(),
         "stCreateTest".into(),
@@ -156,7 +156,7 @@ fn run_test(path: &Path, contents: String) -> datatest_stable::Result<()> {
             env.tx.caller = sender;
             env.tx.gas_limit = unit.transaction.gas_limit[test.indexes.gas].as_u64();
             env.tx.value = unit.transaction.value[test.indexes.value];
-            env.tx.data = convert_to_hex((unit.transaction.data[test.indexes.data].clone()));
+            env.tx.data = convert_to_hex(unit.transaction.data[test.indexes.data].clone());
 
             env.block.number = unit.env.current_number;
             env.block.coinbase = unit.env.current_coinbase;

--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -206,13 +206,7 @@ fn run_test(path: &Path, contents: String) -> datatest_stable::Result<()> {
                         }
                     }
                 }
-                (
-                    Some(_),
-                    ExecutionResult::Halt {
-                        reason: _,
-                        gas_used: _,
-                    },
-                ) => {
+                (Some(_), ExecutionResult::Halt { .. }) => {
                     return Ok(()); //Halt and want an error
                 }
                 _ => {

--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -206,8 +206,8 @@ fn run_test(path: &Path, contents: String) -> datatest_stable::Result<()> {
                         }
                     }
                 }
-                (Some(_), ExecutionResult::Halt { .. }) => {
-                    return Ok(()); //Halt and want an error
+                (Some(_), ExecutionResult::Halt { .. } | ExecutionResult::Revert { .. }) => {
+                    return Ok(()); //Halt/Revert and want an error
                 }
                 _ => {
                     return Err("Expected exception but got none".into());

--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -105,8 +105,11 @@ fn get_ignored_suites() -> HashSet<String> {
     ])
 }
 
-fn convert_to_hex(account_info_code: Bytes) -> Bytes {
-    let hex_string = std::str::from_utf8(&account_info_code[2..]).unwrap(); // we don't need the 0x
+/// Receives a Bytes object with the hex representation
+/// And returns a Bytes object with the decimal representation
+/// Taking the hex numbers by pairs
+fn bytes_in_hex_to_decimal(bytes_in_hex: Bytes) -> Bytes {
+    let hex_string = std::str::from_utf8(&bytes_in_hex[2..]).unwrap(); // we don't need the 0x
     let mut opcodes = Vec::new();
     for i in (0..hex_string.len()).step_by(2) {
         let pair = &hex_string[i..i + 2];
@@ -151,7 +154,7 @@ fn run_test(path: &Path, contents: String) -> datatest_stable::Result<()> {
             env.tx.caller = sender;
             env.tx.gas_limit = unit.transaction.gas_limit[test.indexes.gas].as_u64();
             env.tx.value = unit.transaction.value[test.indexes.value];
-            env.tx.data = convert_to_hex(unit.transaction.data[test.indexes.data].clone());
+            env.tx.data = bytes_in_hex_to_decimal(unit.transaction.data[test.indexes.data].clone());
 
             env.block.number = unit.env.current_number;
             env.block.coinbase = unit.env.current_coinbase;
@@ -168,19 +171,19 @@ fn run_test(path: &Path, contents: String) -> datatest_stable::Result<()> {
             };
             let mut db = match to.clone() {
                 TransactTo::Call(to) => {
-                    let opcodes = convert_to_hex(unit.pre.get(&to).unwrap().code.clone());
+                    let opcodes = bytes_in_hex_to_decimal(unit.pre.get(&to).unwrap().code.clone());
                     Db::new().with_contract(to, opcodes)
                 }
                 TransactTo::Create => {
                     let opcodes =
-                        convert_to_hex(unit.pre.get(&env.tx.caller).unwrap().code.clone());
+                        bytes_in_hex_to_decimal(unit.pre.get(&env.tx.caller).unwrap().code.clone());
                     Db::new().with_contract(env.tx.get_address(), opcodes)
                 }
             };
 
             // Load pre storage into db
             for (address, account_info) in unit.pre.iter() {
-                let opcodes = convert_to_hex(account_info.code.clone());
+                let opcodes = bytes_in_hex_to_decimal(account_info.code.clone());
                 db = db.with_contract(address.to_owned(), opcodes);
                 db.set_account(
                     address.to_owned(),
@@ -223,7 +226,7 @@ fn run_test(path: &Path, contents: String) -> datatest_stable::Result<()> {
             let mut result_state = HashMap::new();
             for address in test.post_state.keys() {
                 let account = res.state.get(address).unwrap();
-                let opcodes = convert_to_hex(account.info.code.clone().unwrap());
+                let opcodes = bytes_in_hex_to_decimal(account.info.code.clone().unwrap());
                 result_state.insert(
                     address.to_owned(),
                     AccountInfo {

--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -39,7 +39,7 @@ fn get_ignored_groups() -> HashSet<String> {
         "eip3855_push0".into(),
         "eip4844_blobs".into(),
         "stZeroCallsRevert".into(),
-        "stSStoreTest".into(),
+        "stSStoreTest".into(), // works!
         "stEIP2930".into(),
         "stSystemOperationsTest".into(),
         "stReturnDataTest".into(),
@@ -65,7 +65,7 @@ fn get_ignored_groups() -> HashSet<String> {
         "stMemoryStressTest".into(),
         "stStaticFlagEnabled".into(),
         "vmTests".into(),
-        "stEIP158Specific".into(),
+        "stEIP158Specific".into(), // works
         "stZeroKnowledge".into(),
         "stLogTests".into(),
         "stBugs".into(),

--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -194,34 +194,7 @@ fn run_test(path: &Path, contents: String) -> datatest_stable::Result<()> {
             let res = evm.transact().unwrap();
 
             match (&test.expect_exception, &res.result) {
-                (
-                    None,
-                    ExecutionResult::Success {
-                        reason,
-                        gas_used,
-                        gas_refunded,
-                        logs,
-                        output,
-                    },
-                ) => {
-                    if let Some((expected_output, output)) =
-                        unit.out.as_ref().zip(res.result.output())
-                    {
-                        if expected_output != output {
-                            return Err("Wrong output".into());
-                        }
-                    }
-                }
-                (None, ExecutionResult::Revert { gas_used, output }) => {
-                    if let Some((expected_output, output)) =
-                        unit.out.as_ref().zip(res.result.output())
-                    {
-                        if expected_output != output {
-                            return Err("Wrong output".into());
-                        }
-                    }
-                }
-                (None, ExecutionResult::Halt { reason, gas_used }) => {
+                (None, _) => {
                     if let Some((expected_output, output)) =
                         unit.out.as_ref().zip(res.result.output())
                     {

--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -203,7 +203,13 @@ fn run_test(path: &Path, contents: String) -> datatest_stable::Result<()> {
                         }
                     }
                 }
-                (Some(_), ExecutionResult::Halt { reason, gas_used }) => {
+                (
+                    Some(_),
+                    ExecutionResult::Halt {
+                        reason: _,
+                        gas_used: _,
+                    },
+                ) => {
                     return Ok(()); //Halt and want an error
                 }
                 _ => {}

--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -77,7 +77,7 @@ fn get_ignored_groups() -> HashSet<String> {
         "stMemoryTest".into(),
         "stRandom".into(),
         "stInitCodeTest".into(),
-        "stBadOpcode".into(),
+        //"stBadOpcode".into(),
         "eip1153_tstore".into(),
         "stSolidityTest".into(),
         "yul".into(),
@@ -212,7 +212,9 @@ fn run_test(path: &Path, contents: String) -> datatest_stable::Result<()> {
                 ) => {
                     return Ok(()); //Halt and want an error
                 }
-                _ => {}
+                _ => {
+                    return Err("Expected exception but got none".into());
+                }
             }
 
             // TODO: use rlp and hash to check logs

--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -199,8 +199,7 @@ fn run_test(path: &Path, contents: String) -> datatest_stable::Result<()> {
             match (&test.expect_exception, &res.result) {
                 (None, _) => {
                     if unit.out.as_ref() != res.result.output() {
-                            return Err("Wrong output".into());
-                        }
+                        return Err("Wrong output".into());
                     }
                 }
                 (Some(_), ExecutionResult::Halt { .. } | ExecutionResult::Revert { .. }) => {

--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -34,7 +34,7 @@ fn get_ignored_groups() -> HashSet<String> {
         "stEIP5656-MCOPY".into(),
         "stEIP3651-warmcoinbase".into(),
         "stArgsZeroOneBalance".into(),
-        "stTimeConsuming".into(),
+        //"stTimeConsuming".into(), // this works, but it's REALLY is time consuming
         "stRevertTest".into(),
         "eip3855_push0".into(),
         "eip4844_blobs".into(),

--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -77,7 +77,7 @@ fn get_ignored_groups() -> HashSet<String> {
         "stMemoryTest".into(),
         "stRandom".into(),
         "stInitCodeTest".into(),
-        //"stBadOpcode".into(),
+        "stBadOpcode".into(),
         "eip1153_tstore".into(),
         "stSolidityTest".into(),
         "yul".into(),

--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -39,7 +39,6 @@ fn get_ignored_groups() -> HashSet<String> {
         "eip3855_push0".into(),
         "eip4844_blobs".into(),
         "stZeroCallsRevert".into(),
-        "stSStoreTest".into(), // works!
         "stEIP2930".into(),
         "stSystemOperationsTest".into(),
         "stReturnDataTest".into(),
@@ -55,7 +54,6 @@ fn get_ignored_groups() -> HashSet<String> {
         "stEIP150singleCodeGasPrices".into(),
         "stCreate2".into(),
         "stSpecialTest".into(),
-        "stSLoadTest".into(), //works
         "stRecursiveCreate".into(),
         "vmIOandFlowOperations".into(),
         "stEIP150Specific".into(),
@@ -65,13 +63,11 @@ fn get_ignored_groups() -> HashSet<String> {
         "stMemoryStressTest".into(),
         "stStaticFlagEnabled".into(),
         "vmTests".into(),
-        "stEIP158Specific".into(), // works
         "stZeroKnowledge".into(),
         "stLogTests".into(),
         "stBugs".into(),
         "stEIP1559".into(),
         "stStaticCall".into(),
-        "stCallDelegateCodesHomestead".into(), // works
         "stMemExpandingEIP150Calls".into(),
         "stTransactionTest".into(),
         "eip3860_initcode".into(),
@@ -84,7 +80,6 @@ fn get_ignored_groups() -> HashSet<String> {
         "stBadOpcode".into(),
         "eip1153_tstore".into(),
         "stSolidityTest".into(),
-        "stCallDelegateCodesCallCodeHomestead".into(), //works
         "yul".into(),
         "stEIP3607".into(),
         "stCreateTest".into(),


### PR DESCRIPTION
Closes https://github.com/lambdaclass/evm_mlir/issues/386
## Summary
This PR fix an issue with the parsing of the transaction data of EF tests
## Changes
- Use of the function to parse from the hex string to hex value
- Updated the list of ignored group of tests
- Small fix to the `call` syscall, using `checked_sub` so it doesn't panic