### PR TITLE
refactor: enhance error handling in precompiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,8 +1255,9 @@ dependencies = [
 
 [[package]]
 name = "lambdaworks-math"
-version = "0.9.0"
-source = "git+https://github.com/lambdaclass/lambdaworks.git?rev=264f29b#264f29b5783f63b4553775ca6fee0a3a174096ba"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1bd2632acbd9957afc5aeec07ad39f078ae38656654043bf16e046fa2730e23"
 dependencies = [
  "rayon",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ bitflags = "2.5.0"
 secp256k1 = { version = "0.29.0", features = ["recovery"] }
 sha2 = "0.10.8"
 ripemd = "0.1.3"
-lambdaworks-math = { git = "https://github.com/lambdaclass/lambdaworks.git", rev = "264f29b" }
+lambdaworks-math = "0.10.0"
 
 [dev-dependencies]
 hex-literal = "0.4.1"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -163,7 +163,7 @@ pub mod call_opcode {
 pub mod precompiles {
     pub const ECRECOVER_COST: u64 = 3000;
     pub const ECRECOVER_ADDRESS: u64 = 0x01;
-    pub const SHA2_256_COST: u64 = 60;
+    pub const SHA2_256_STATIC_COST: u64 = 60;
     pub const SHA2_256_ADDRESS: u64 = 0x02;
     pub const RIPEMD_160_COST: u64 = 600;
     pub const RIPEMD_160_ADDRESS: u64 = 0x03;

--- a/src/precompiles.rs
+++ b/src/precompiles.rs
@@ -2,7 +2,7 @@ use crate::{
     constants::precompiles::{
         blake2_gas_cost, ecpairing_dynamic_cost, identity_dynamic_cost, ripemd_160_dynamic_cost,
         sha2_256_dynamic_cost, ECADD_COST, ECMUL_COST, ECPAIRING_STATIC_COST, ECRECOVER_COST,
-        IDENTITY_COST, RIPEMD_160_COST, SHA2_256_COST,
+        IDENTITY_COST, RIPEMD_160_COST, SHA2_256_STATIC_COST,
     },
     primitives::U256,
     result::PrecompileError,
@@ -75,14 +75,18 @@ pub fn identity(
     Ok(calldata.clone())
 }
 
-pub fn sha2_256(calldata: &Bytes, gas_limit: u64, consumed_gas: &mut u64) -> Bytes {
-    let gas_cost = SHA2_256_COST + sha2_256_dynamic_cost(calldata.len() as u64);
+pub fn sha2_256(
+    calldata: &Bytes,
+    gas_limit: u64,
+    consumed_gas: &mut u64,
+) -> Result<Bytes, PrecompileError> {
+    let gas_cost = SHA2_256_STATIC_COST + sha2_256_dynamic_cost(calldata.len() as u64);
     if gas_limit < gas_cost {
-        return Bytes::new();
+        return Err(PrecompileError::NotEnoughGas);
     }
     *consumed_gas += gas_cost;
     let hash = sha2::Sha256::digest(calldata);
-    Bytes::copy_from_slice(&hash)
+    Ok(Bytes::copy_from_slice(&hash))
 }
 
 pub fn ripemd_160(calldata: &Bytes, gas_limit: u64, consumed_gas: &mut u64) -> Bytes {

--- a/src/precompiles.rs
+++ b/src/precompiles.rs
@@ -116,15 +116,12 @@ pub fn modexp(
 
     // Cast sizes as usize and check for overflow.
     // Bigger sizes are not accepted, as memory can't index bigger values.
-    let Ok(b_size) = usize::try_from(U256::from_big_endian(&calldata[0..32])) else {
-        return Err(PrecompileError::InvalidCalldata);
-    };
-    let Ok(e_size) = usize::try_from(U256::from_big_endian(&calldata[32..64])) else {
-        return Err(PrecompileError::InvalidCalldata);
-    };
-    let Ok(m_size) = usize::try_from(U256::from_big_endian(&calldata[64..96])) else {
-        return Err(PrecompileError::InvalidCalldata);
-    };
+    let b_size = usize::try_from(U256::from_big_endian(&calldata[0..32]))
+        .map_err(|_| PrecompileError::InvalidCalldata)?;
+    let e_size = usize::try_from(U256::from_big_endian(&calldata[32..64]))
+        .map_err(|_| PrecompileError::InvalidCalldata)?;
+    let m_size = usize::try_from(U256::from_big_endian(&calldata[64..96]))
+        .map_err(|_| PrecompileError::InvalidCalldata)?;
 
     // Check if calldata contains all values
     let params_len = 96 + b_size + e_size + m_size;

--- a/src/precompiles.rs
+++ b/src/precompiles.rs
@@ -89,17 +89,17 @@ pub fn sha2_256(
     Ok(Bytes::copy_from_slice(&hash))
 }
 
-pub fn ripemd_160(calldata: &Bytes, gas_limit: u64, consumed_gas: &mut u64) -> Bytes {
+pub fn ripemd_160(calldata: &Bytes, gas_limit: u64, consumed_gas: &mut u64) -> Result<Bytes, PrecompileError> {
     let gas_cost = RIPEMD_160_COST + ripemd_160_dynamic_cost(calldata.len() as u64);
     if gas_limit < gas_cost {
-        return Bytes::new();
+        return Err(PrecompileError::NotEnoughGas);
     }
     *consumed_gas += gas_cost;
     let mut hasher = ripemd::Ripemd160::new();
     hasher.update(calldata);
     let mut output = [0u8; 32];
     hasher.finalize_into((&mut output[12..]).into());
-    Bytes::copy_from_slice(&output)
+    Ok(Bytes::copy_from_slice(&output))
 }
 
 pub fn modexp(calldata: &Bytes, gas_limit: u64, consumed_gas: &mut u64) -> Bytes {

--- a/src/precompiles.rs
+++ b/src/precompiles.rs
@@ -62,13 +62,17 @@ pub fn ecrecover(
     Ok(Bytes::copy_from_slice(&address_hash))
 }
 
-pub fn identity(calldata: &Bytes, gas_limit: u64, consumed_gas: &mut u64) -> Bytes {
+pub fn identity(
+    calldata: &Bytes,
+    gas_limit: u64,
+    consumed_gas: &mut u64,
+) -> Result<Bytes, PrecompileError> {
     let gas_cost = IDENTITY_COST + identity_dynamic_cost(calldata.len() as u64);
     if gas_limit < gas_cost {
-        return Bytes::new();
+        return Err(PrecompileError::NotEnoughGas);
     }
     *consumed_gas += gas_cost;
-    calldata.clone()
+    Ok(calldata.clone())
 }
 
 pub fn sha2_256(calldata: &Bytes, gas_limit: u64, consumed_gas: &mut u64) -> Bytes {

--- a/src/precompiles.rs
+++ b/src/precompiles.rs
@@ -1,13 +1,6 @@
-use crate::{
-    constants::precompiles::{
-        blake2_gas_cost, ecpairing_dynamic_cost, identity_dynamic_cost, ripemd_160_dynamic_cost,
-        sha2_256_dynamic_cost, ECADD_COST, ECMUL_COST, ECPAIRING_STATIC_COST, ECRECOVER_COST,
-        IDENTITY_COST, RIPEMD_160_COST, SHA2_256_STATIC_COST,
-    },
-    primitives::U256,
-    result::PrecompileError,
-};
+use crate::{constants::precompiles::*, primitives::U256, result::PrecompileError};
 use bytes::Bytes;
+use ethereum_types::Address;
 use lambdaworks_math::{
     cyclic_group::IsGroup,
     elliptic_curve::{
@@ -508,6 +501,52 @@ pub fn blake2f(
     let out: Vec<u8> = h.iter().flat_map(|&num| num.to_le_bytes()).collect();
 
     Ok(Bytes::from(out))
+}
+
+pub fn is_precompile(callee_address: Address) -> bool {
+    let addr_as_u64 = callee_address.to_low_u64_be();
+    // TODO: replace 10 with point evaluation address constant
+    callee_address[0..12] == [0u8; 12] && (ECRECOVER_ADDRESS..=10).contains(&addr_as_u64)
+}
+
+pub fn execute_precompile(
+    callee_address: Address,
+    calldata: Bytes,
+    gas_to_send: u64,
+    consumed_gas: &mut u64,
+) -> Result<Bytes, PrecompileError> {
+    match callee_address {
+        x if x == Address::from_low_u64_be(ECRECOVER_ADDRESS) => {
+            ecrecover(&calldata, gas_to_send, consumed_gas)
+        }
+        x if x == Address::from_low_u64_be(IDENTITY_ADDRESS) => {
+            identity(&calldata, gas_to_send, consumed_gas)
+        }
+        x if x == Address::from_low_u64_be(SHA2_256_ADDRESS) => {
+            sha2_256(&calldata, gas_to_send, consumed_gas)
+        }
+        x if x == Address::from_low_u64_be(RIPEMD_160_ADDRESS) => {
+            ripemd_160(&calldata, gas_to_send, consumed_gas)
+        }
+        x if x == Address::from_low_u64_be(MODEXP_ADDRESS) => {
+            modexp(&calldata, gas_to_send, consumed_gas)
+        }
+        x if x == Address::from_low_u64_be(ECADD_ADDRESS) => {
+            ecadd(&calldata, gas_to_send, consumed_gas)
+        }
+        x if x == Address::from_low_u64_be(ECMUL_ADDRESS) => {
+            ecmul(&calldata, gas_to_send, consumed_gas)
+        }
+        x if x == Address::from_low_u64_be(ECPAIRING_ADDRESS) => {
+            ecpairing(&calldata, gas_to_send, consumed_gas)
+        }
+        x if x == Address::from_low_u64_be(BLAKE2F_ADDRESS) => {
+            blake2f(&calldata, gas_to_send, consumed_gas)
+        }
+        _ => {
+            unreachable!()
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/precompiles.rs
+++ b/src/precompiles.rs
@@ -643,7 +643,7 @@ mod tests {
 
         let result = ecadd(&calldata, gas_limit, &mut consumed_gas);
 
-        assert!(result.is_err());
+        assert!(matches!(result, Err(PrecompileError::InvalidEcPoint)));
         assert_eq!(consumed_gas, expected_gas);
     }
 
@@ -665,7 +665,7 @@ mod tests {
 
         let result = ecadd(&calldata, gas_limit, &mut consumed_gas);
 
-        assert!(result.is_err());
+        assert!(matches!(result, Err(PrecompileError::InvalidEcPoint)));
         assert_eq!(consumed_gas, expected_gas);
     }
 
@@ -687,7 +687,7 @@ mod tests {
 
         let result = ecadd(&calldata, gas_limit, &mut consumed_gas);
 
-        assert!(result.is_err());
+        assert!(matches!(result, Err(PrecompileError::InvalidCalldata)));
         assert_eq!(consumed_gas, gas_limit);
     }
 
@@ -708,7 +708,7 @@ mod tests {
 
         let result = ecadd(&calldata, gas_limit, &mut consumed_gas);
 
-        assert!(result.is_err());
+        assert!(matches!(result, Err(PrecompileError::NotEnoughGas)));
         assert_eq!(consumed_gas, gas_limit);
     }
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -383,5 +383,6 @@ pub enum OutOfGasError {
 pub enum PrecompileError {
     InvalidCalldata,
     NotEnoughGas,
+    Secp256k1Error,
     InvalidEcPoint,
 }

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -322,10 +322,12 @@ impl<'c> SyscallContext<'c> {
                     Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
                 }
             }
-            x if x == Address::from_low_u64_be(precompiles::ECPAIRING_ADDRESS) => (
-                call_opcode::SUCCESS_RETURN_CODE,
-                ecpairing(&calldata, gas_to_send, consumed_gas),
-            ),
+            x if x == Address::from_low_u64_be(precompiles::ECPAIRING_ADDRESS) => {
+                match ecpairing(&calldata, gas_to_send, consumed_gas) {
+                    Ok(res) => (call_opcode::SUCCESS_RETURN_CODE, res),
+                    Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
+                }
+            }
             x if x == Address::from_low_u64_be(precompiles::BLAKE2F_ADDRESS) => (
                 call_opcode::SUCCESS_RETURN_CODE,
                 blake2f(&calldata, gas_to_send, consumed_gas).unwrap_or_default(),

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -290,10 +290,12 @@ impl<'c> SyscallContext<'c> {
         let calldata = Bytes::copy_from_slice(&self.inner_context.memory[off..off + size]);
 
         let (return_code, return_data) = match callee_address {
-            x if x == Address::from_low_u64_be(precompiles::ECRECOVER_ADDRESS) => (
-                call_opcode::SUCCESS_RETURN_CODE,
-                ecrecover(&calldata, gas_to_send, consumed_gas).unwrap_or_default(),
-            ),
+            x if x == Address::from_low_u64_be(precompiles::ECRECOVER_ADDRESS) => {
+                match ecrecover(&calldata, gas_to_send, consumed_gas) {
+                    Ok(res) => (call_opcode::SUCCESS_RETURN_CODE, res),
+                    Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
+                }
+            }
             x if x == Address::from_low_u64_be(precompiles::IDENTITY_ADDRESS) => (
                 call_opcode::SUCCESS_RETURN_CODE,
                 identity(&calldata, gas_to_send, consumed_gas),

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -316,10 +316,12 @@ impl<'c> SyscallContext<'c> {
                     Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
                 }
             }
-            x if x == Address::from_low_u64_be(precompiles::ECMUL_ADDRESS) => (
-                call_opcode::SUCCESS_RETURN_CODE,
-                ecmul(&calldata, gas_to_send, consumed_gas),
-            ),
+            x if x == Address::from_low_u64_be(precompiles::ECMUL_ADDRESS) => {
+                match ecmul(&calldata, gas_to_send, consumed_gas) {
+                    Ok(res) => (call_opcode::SUCCESS_RETURN_CODE, res),
+                    Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
+                }
+            }
             x if x == Address::from_low_u64_be(precompiles::ECPAIRING_ADDRESS) => (
                 call_opcode::SUCCESS_RETURN_CODE,
                 ecpairing(&calldata, gas_to_send, consumed_gas),

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -302,10 +302,12 @@ impl<'c> SyscallContext<'c> {
                     Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
                 }
             }
-            x if x == Address::from_low_u64_be(precompiles::SHA2_256_ADDRESS) => (
-                call_opcode::SUCCESS_RETURN_CODE,
-                sha2_256(&calldata, gas_to_send, consumed_gas),
-            ),
+            x if x == Address::from_low_u64_be(precompiles::SHA2_256_ADDRESS) => {
+                match sha2_256(&calldata, gas_to_send, consumed_gas) {
+                    Ok(res) => (call_opcode::SUCCESS_RETURN_CODE, res),
+                    Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
+                }
+            }
             x if x == Address::from_low_u64_be(precompiles::RIPEMD_160_ADDRESS) => (
                 call_opcode::SUCCESS_RETURN_CODE,
                 ripemd_160(&calldata, gas_to_send, consumed_gas),

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -308,10 +308,12 @@ impl<'c> SyscallContext<'c> {
                     Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
                 }
             }
-            x if x == Address::from_low_u64_be(precompiles::RIPEMD_160_ADDRESS) => (
-                call_opcode::SUCCESS_RETURN_CODE,
-                ripemd_160(&calldata, gas_to_send, consumed_gas),
-            ),
+            x if x == Address::from_low_u64_be(precompiles::RIPEMD_160_ADDRESS) => {
+                match ripemd_160(&calldata, gas_to_send, consumed_gas) {
+                    Ok(res) => (call_opcode::SUCCESS_RETURN_CODE, res),
+                    Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
+                }
+            }
             x if x == Address::from_low_u64_be(precompiles::MODEXP_ADDRESS) => (
                 call_opcode::SUCCESS_RETURN_CODE,
                 modexp(&calldata, gas_to_send, consumed_gas),

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -18,15 +18,13 @@
 use std::ffi::c_void;
 
 use crate::{
-    constants::{call_opcode, gas_cost, precompiles, CallType},
+    constants::{call_opcode, gas_cost, CallType},
     context::Context,
     db::AccountInfo,
     env::{Env, TransactTo},
     executor::{Executor, OptLevel},
     journal::Journal,
-    precompiles::{
-        blake2f, ecadd, ecmul, ecpairing, ecrecover, identity, modexp, ripemd_160, sha2_256,
-    },
+    precompiles::*,
     primitives::{Address, Bytes, B256, U256 as EU256},
     program::Program,
     result::{EVMError, ExecutionResult, HaltReason, Output, ResultAndState, SuccessReason},
@@ -294,185 +292,132 @@ impl<'c> SyscallContext<'c> {
         let size = args_size as usize;
         let calldata = Bytes::copy_from_slice(&self.inner_context.memory[off..off + size]);
 
-        let (return_code, return_data) = match callee_address {
-            x if x == Address::from_low_u64_be(precompiles::ECRECOVER_ADDRESS) => {
-                match ecrecover(&calldata, gas_to_send, consumed_gas) {
-                    Ok(res) => (call_opcode::SUCCESS_RETURN_CODE, res),
-                    Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
-                }
+        let (return_code, return_data) = if is_precompile(callee_address) {
+            match execute_precompile(callee_address, calldata, gas_to_send, consumed_gas) {
+                Ok(res) => (call_opcode::SUCCESS_RETURN_CODE, res),
+                Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
             }
-            x if x == Address::from_low_u64_be(precompiles::IDENTITY_ADDRESS) => {
-                match identity(&calldata, gas_to_send, consumed_gas) {
-                    Ok(res) => (call_opcode::SUCCESS_RETURN_CODE, res),
-                    Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
+        } else {
+            // Execute subcontext
+            //TODO: Add call depth check
+            //TODO: Check that the args offsets and sizes are correct -> This from the MLIR side
+            let value = value_to_transfer.to_primitive_u256();
+            let call_type = CallType::try_from(call_type)
+                .expect("Error while parsing CallType on call syscall");
+
+            //TODO: This should instead add the account fetch (warm or cold) cost
+            //For the moment we consider warm access
+            let callee_account = match self.journal.get_account(&callee_address) {
+                Some(acc) => {
+                    *consumed_gas = call_opcode::WARM_MEMORY_ACCESS_COST;
+                    acc
                 }
-            }
-            x if x == Address::from_low_u64_be(precompiles::SHA2_256_ADDRESS) => {
-                match sha2_256(&calldata, gas_to_send, consumed_gas) {
-                    Ok(res) => (call_opcode::SUCCESS_RETURN_CODE, res),
-                    Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
+                None => {
+                    *consumed_gas = 0;
+                    return call_opcode::REVERT_RETURN_CODE;
                 }
-            }
-            x if x == Address::from_low_u64_be(precompiles::RIPEMD_160_ADDRESS) => {
-                match ripemd_160(&calldata, gas_to_send, consumed_gas) {
-                    Ok(res) => (call_opcode::SUCCESS_RETURN_CODE, res),
-                    Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
+            };
+
+            let caller_address = self.env.tx.get_address();
+            let caller_account = self
+                .journal
+                .get_account(&caller_address)
+                .unwrap_or_default();
+
+            let mut stipend = 0;
+            if !value.is_zero() {
+                if caller_account.balance < value {
+                    //There isn't enough balance to send
+                    return call_opcode::REVERT_RETURN_CODE;
                 }
-            }
-            x if x == Address::from_low_u64_be(precompiles::MODEXP_ADDRESS) => {
-                match modexp(&calldata, gas_to_send, consumed_gas) {
-                    Ok(res) => (call_opcode::SUCCESS_RETURN_CODE, res),
-                    Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
+                *consumed_gas += call_opcode::NOT_ZERO_VALUE_COST;
+                if callee_account.is_empty() {
+                    *consumed_gas += call_opcode::EMPTY_CALLEE_COST;
                 }
-            }
-            x if x == Address::from_low_u64_be(precompiles::ECADD_ADDRESS) => {
-                match ecadd(&calldata, gas_to_send, consumed_gas) {
-                    Ok(res) => (call_opcode::SUCCESS_RETURN_CODE, res),
-                    Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
+                if available_gas < *consumed_gas {
+                    return call_opcode::REVERT_RETURN_CODE; //It acctually doesn't matter what we return here
                 }
+                stipend = call_opcode::STIPEND_GAS_ADDITION;
+
+                //TODO: Maybe we should increment the nonce too
+                let caller_balance = caller_account.balance;
+                self.journal
+                    .set_balance(&caller_address, caller_balance - value);
+
+                let callee_balance = callee_account.balance;
+                self.journal
+                    .set_balance(&callee_address, callee_balance + value);
             }
-            x if x == Address::from_low_u64_be(precompiles::ECMUL_ADDRESS) => {
-                match ecmul(&calldata, gas_to_send, consumed_gas) {
-                    Ok(res) => (call_opcode::SUCCESS_RETURN_CODE, res),
-                    Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
-                }
-            }
-            x if x == Address::from_low_u64_be(precompiles::ECPAIRING_ADDRESS) => {
-                match ecpairing(&calldata, gas_to_send, consumed_gas) {
-                    Ok(res) => (call_opcode::SUCCESS_RETURN_CODE, res),
-                    Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
-                }
-            }
-            x if x == Address::from_low_u64_be(precompiles::BLAKE2F_ADDRESS) => {
-                match blake2f(&calldata, gas_to_send, consumed_gas) {
-                    Ok(res) => (call_opcode::SUCCESS_RETURN_CODE, res),
-                    Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
-                }
-            }
-            _ => {
-                // Execute subcontext
-                //TODO: Add call depth check
-                //TODO: Check that the args offsets and sizes are correct -> This from the MLIR side
-                let value = value_to_transfer.to_primitive_u256();
-                let call_type = CallType::try_from(call_type)
-                    .expect("Error while parsing CallType on call syscall");
 
-                //TODO: This should instead add the account fetch (warm or cold) cost
-                //For the moment we consider warm access
-                let callee_account = match self.journal.get_account(&callee_address) {
-                    Some(acc) => {
-                        *consumed_gas = call_opcode::WARM_MEMORY_ACCESS_COST;
-                        acc
-                    }
-                    None => {
-                        *consumed_gas = 0;
-                        return call_opcode::REVERT_RETURN_CODE;
-                    }
-                };
+            let remaining_gas = available_gas.saturating_sub(*consumed_gas);
+            gas_to_send = std::cmp::min(
+                remaining_gas / call_opcode::GAS_CAP_DIVISION_FACTOR,
+                gas_to_send,
+            );
+            *consumed_gas += gas_to_send;
+            gas_to_send += stipend;
 
-                let caller_address = self.env.tx.get_address();
-                let caller_account = self
-                    .journal
-                    .get_account(&caller_address)
-                    .unwrap_or_default();
+            let mut env = self.env.clone();
 
-                let mut stipend = 0;
-                if !value.is_zero() {
-                    if caller_account.balance < value {
-                        //There isn't enough balance to send
-                        return call_opcode::REVERT_RETURN_CODE;
-                    }
-                    *consumed_gas += call_opcode::NOT_ZERO_VALUE_COST;
-                    if callee_account.is_empty() {
-                        *consumed_gas += call_opcode::EMPTY_CALLEE_COST;
-                    }
-                    if available_gas < *consumed_gas {
-                        return call_opcode::REVERT_RETURN_CODE; //It acctually doesn't matter what we return here
-                    }
-                    stipend = call_opcode::STIPEND_GAS_ADDITION;
+            //TODO: Check if calling `get_address()` here is ok
+            let this_address = self.env.tx.get_address();
+            let (new_frame_caller, new_value, transact_to) = match call_type {
+                CallType::Call | CallType::StaticCall => (this_address, value, callee_address),
+                CallType::CallCode => (this_address, value, this_address),
+                CallType::DelegateCall => (self.call_frame.caller, self.env.tx.value, this_address),
+            };
 
-                    //TODO: Maybe we should increment the nonce too
-                    let caller_balance = caller_account.balance;
-                    self.journal
-                        .set_balance(&caller_address, caller_balance - value);
+            env.tx.value = new_value;
+            env.tx.transact_to = TransactTo::Call(transact_to);
+            env.tx.gas_limit = gas_to_send;
 
-                    let callee_balance = callee_account.balance;
-                    self.journal
-                        .set_balance(&callee_address, callee_balance + value);
-                }
+            //Copy the calldata from memory
+            let off = args_offset as usize;
+            let size = args_size as usize;
+            env.tx.data = Bytes::from(self.inner_context.memory[off..off + size].to_vec());
 
-                let remaining_gas = available_gas.saturating_sub(*consumed_gas);
-                gas_to_send = std::cmp::min(
-                    remaining_gas / call_opcode::GAS_CAP_DIVISION_FACTOR,
-                    gas_to_send,
-                );
-                *consumed_gas += gas_to_send;
-                gas_to_send += stipend;
+            //NOTE: We could optimize this by not making the call if the bytecode is zero.
+            //We would have to refund the stipend here
+            //TODO: Check if returning REVERT because of database fail is ok
+            let bytecode = self.journal.code_by_address(&callee_address);
 
-                let mut env = self.env.clone();
+            let program = Program::from_bytecode(&bytecode);
 
-                //TODO: Check if calling `get_address()` here is ok
-                let this_address = self.env.tx.get_address();
-                let (new_frame_caller, new_value, transact_to) = match call_type {
-                    CallType::Call | CallType::StaticCall => (this_address, value, callee_address),
-                    CallType::CallCode => (this_address, value, this_address),
-                    CallType::DelegateCall => {
-                        (self.call_frame.caller, self.env.tx.value, this_address)
-                    }
-                };
+            let context = Context::new();
+            let module = context
+                .compile(&program, Default::default())
+                .expect("failed to compile program");
 
-                env.tx.value = new_value;
-                env.tx.transact_to = TransactTo::Call(transact_to);
-                env.tx.gas_limit = gas_to_send;
+            let is_static = self.call_frame.ctx_is_static || call_type == CallType::StaticCall;
 
-                //Copy the calldata from memory
-                let off = args_offset as usize;
-                let size = args_size as usize;
-                env.tx.data = Bytes::from(self.inner_context.memory[off..off + size].to_vec());
+            let call_frame = CallFrame {
+                caller: new_frame_caller,
+                ctx_is_static: is_static,
+                ..Default::default()
+            };
 
-                //NOTE: We could optimize this by not making the call if the bytecode is zero.
-                //We would have to refund the stipend here
-                //TODO: Check if returning REVERT because of database fail is ok
-                let bytecode = self.journal.code_by_address(&callee_address);
+            let journal = self.journal.eject_base();
 
-                let program = Program::from_bytecode(&bytecode);
+            let mut context = SyscallContext::new(env.clone(), journal, call_frame);
+            let executor = Executor::new(&module, &context, OptLevel::Aggressive);
 
-                let context = Context::new();
-                let module = context
-                    .compile(&program, Default::default())
-                    .expect("failed to compile program");
+            executor.execute(&mut context, env.tx.gas_limit);
 
-                let is_static = self.call_frame.ctx_is_static || call_type == CallType::StaticCall;
+            let result = context.get_result().unwrap().result;
 
-                let call_frame = CallFrame {
-                    caller: new_frame_caller,
-                    ctx_is_static: is_static,
-                    ..Default::default()
-                };
-
-                let journal = self.journal.eject_base();
-
-                let mut context = SyscallContext::new(env.clone(), journal, call_frame);
-                let executor = Executor::new(&module, &context, OptLevel::Aggressive);
-
-                executor.execute(&mut context, env.tx.gas_limit);
-
-                let result = context.get_result().unwrap().result;
-
-                let unused_gas = gas_to_send - result.gas_used();
-                *consumed_gas -= unused_gas;
-                *consumed_gas -= result.gas_refunded();
-                let return_code = if result.is_success() {
-                    self.journal.extend_from_successful(context.journal);
-                    call_opcode::SUCCESS_RETURN_CODE
-                } else {
-                    //TODO: If we revert, should we still send the value to the called contract?
-                    self.journal.extend_from_reverted(context.journal);
-                    call_opcode::REVERT_RETURN_CODE
-                };
-                let output = result.into_output().unwrap_or_default();
-                (return_code, output)
-            }
+            let unused_gas = gas_to_send - result.gas_used();
+            *consumed_gas -= unused_gas;
+            *consumed_gas -= result.gas_refunded();
+            let return_code = if result.is_success() {
+                self.journal.extend_from_successful(context.journal);
+                call_opcode::SUCCESS_RETURN_CODE
+            } else {
+                //TODO: If we revert, should we still send the value to the called contract?
+                self.journal.extend_from_reverted(context.journal);
+                call_opcode::REVERT_RETURN_CODE
+            };
+            let output = result.into_output().unwrap_or_default();
+            (return_code, output)
         };
 
         //TODO: This copying mechanism may be improved with a safe copy_from_slice which would

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -296,10 +296,12 @@ impl<'c> SyscallContext<'c> {
                     Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
                 }
             }
-            x if x == Address::from_low_u64_be(precompiles::IDENTITY_ADDRESS) => (
-                call_opcode::SUCCESS_RETURN_CODE,
-                identity(&calldata, gas_to_send, consumed_gas),
-            ),
+            x if x == Address::from_low_u64_be(precompiles::IDENTITY_ADDRESS) => {
+                match identity(&calldata, gas_to_send, consumed_gas) {
+                    Ok(res) => (call_opcode::SUCCESS_RETURN_CODE, res),
+                    Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
+                }
+            }
             x if x == Address::from_low_u64_be(precompiles::SHA2_256_ADDRESS) => (
                 call_opcode::SUCCESS_RETURN_CODE,
                 sha2_256(&calldata, gas_to_send, consumed_gas),

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -338,10 +338,12 @@ impl<'c> SyscallContext<'c> {
                     Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
                 }
             }
-            x if x == Address::from_low_u64_be(precompiles::BLAKE2F_ADDRESS) => (
-                call_opcode::SUCCESS_RETURN_CODE,
-                blake2f(&calldata, gas_to_send, consumed_gas).unwrap_or_default(),
-            ),
+            x if x == Address::from_low_u64_be(precompiles::BLAKE2F_ADDRESS) => {
+                match blake2f(&calldata, gas_to_send, consumed_gas) {
+                    Ok(res) => (call_opcode::SUCCESS_RETURN_CODE, res),
+                    Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
+                }
+            }
             _ => {
                 // Execute subcontext
                 //TODO: Add call depth check

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -314,10 +314,12 @@ impl<'c> SyscallContext<'c> {
                     Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
                 }
             }
-            x if x == Address::from_low_u64_be(precompiles::MODEXP_ADDRESS) => (
-                call_opcode::SUCCESS_RETURN_CODE,
-                modexp(&calldata, gas_to_send, consumed_gas),
-            ),
+            x if x == Address::from_low_u64_be(precompiles::MODEXP_ADDRESS) => {
+                match modexp(&calldata, gas_to_send, consumed_gas) {
+                    Ok(res) => (call_opcode::SUCCESS_RETURN_CODE, res),
+                    Err(_) => (call_opcode::REVERT_RETURN_CODE, Bytes::new()),
+                }
+            }
             x if x == Address::from_low_u64_be(precompiles::ECADD_ADDRESS) => {
                 match ecadd(&calldata, gas_to_send, consumed_gas) {
                     Ok(res) => (call_opcode::SUCCESS_RETURN_CODE, res),


### PR DESCRIPTION
Closes #388.

## Summary
Changes the way all precompiles are called and error-handled.

## Changes
- Make all precompiles return a specific `PrecompileError` on error cases.
- Update `lambdaworks-math` dependency to the latest version.
- Fix gas consumption on `InvalidEcPoint` cases of `ecadd`, `ecmul` and `ecpairing`.