### PR TITLE
Ef tests observation

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.default]
+slow-timeout = { period = "5s", terminate-after = 4 }

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,24 @@ test:
 test-eth: check-ethtests
 	cargo nextest run --workspace --all-features --no-capture --no-fail-fast -E 'binary(ef_tests)'
 
+ETH_TESTS := \
+	Cancun/stEIP1153-transientStorage \
+	Cancun/stEIP4844-blobtransactions \
+	Cancun/stEIP5656-MCOPY \
+	Pyspecs/berlin \
+	Pyspecs/byzantium \
+	Pyspecs/cancun \
+	Pyspecs/frontier \
+	Pyspecs/homestead \
+	Pyspecs/istanbul \
+	Pyspecs/shanghai \
+
+test-eth-all: check-ethtests
+	@for file in $(ETH_TESTS); do \
+		echo "Running test-eth with TEST=$$file"; \
+		TEST=$$file $(MAKE) test-eth; \
+	done
+
 revm-comparison:
 	$(MAKE) build-revm-comparison
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ test:
 	cargo nextest run --workspace --all-features --no-capture -E 'all() - binary(ef_tests)'
 
 test-eth: check-ethtests
-	cargo nextest run --workspace --all-features --no-capture -E 'binary(ef_tests)'
+	cargo nextest run --workspace --all-features --no-capture --no-fail-fast -E 'binary(ef_tests)'
 
 revm-comparison:
 	$(MAKE) build-revm-comparison

--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
+    env,
     path::Path,
 };
 mod ef_tests_executor;
@@ -241,4 +242,8 @@ fn run_test(path: &Path, contents: String) -> datatest_stable::Result<()> {
     Ok(())
 }
 
-datatest_stable::harness!(run_test, "ethtests/GeneralStateTests/", r"^.*/*.json",);
+datatest_stable::harness!(
+    run_test,
+    format!("ethtests/GeneralStateTests/{}", env::var("TEST").unwrap()),
+    r"^.*/*.json",
+);

--- a/tests/ef_tests.rs
+++ b/tests/ef_tests.rs
@@ -1,109 +1,8 @@
-use std::{
-    collections::{HashMap, HashSet},
-    env,
-    path::Path,
-};
+use std::{collections::HashMap, env, path::Path};
 mod ef_tests_executor;
 use bytes::Bytes;
 use ef_tests_executor::models::{AccountInfo, TestSuite};
 use evm_mlir::{db::Db, env::TransactTo, result::ExecutionResult, Env, Evm};
-
-fn get_group_name_from_path(path: &Path) -> String {
-    // Gets the parent directory's name.
-    // Example: ethtests/GeneralStateTests/stArgsZeroOneBalance/addmodNonConst.json
-    // -> stArgsZeroOneBalance
-    path.ancestors()
-        .into_iter()
-        .nth(1)
-        .unwrap()
-        .file_name()
-        .unwrap()
-        .to_str()
-        .unwrap()
-        .to_string()
-}
-
-fn get_suite_name_from_path(path: &Path) -> String {
-    // Example: ethtests/GeneralStateTests/stArgsZeroOneBalance/addmodNonConst.json
-    // -> addmodNonConst
-    path.file_stem().unwrap().to_str().unwrap().to_string()
-}
-
-fn get_ignored_groups() -> HashSet<String> {
-    HashSet::from([
-        "stEIP4844-blobtransactions".into(),
-        "stEIP5656-MCOPY".into(),
-        "stEIP3651-warmcoinbase".into(),
-        "stArgsZeroOneBalance".into(),
-        //"stTimeConsuming".into(), // this works, but it's REALLY time consuming
-        "stRevertTest".into(),
-        "eip3855_push0".into(),
-        "eip4844_blobs".into(),
-        "stZeroCallsRevert".into(),
-        "stEIP2930".into(),
-        "stSystemOperationsTest".into(),
-        "stReturnDataTest".into(),
-        "vmPerformance".into(),
-        "stHomesteadSpecific".into(),
-        "stStackTests".into(),
-        "eip5656_mcopy".into(),
-        "eip6780_selfdestruct".into(),
-        "stCallCreateCallCodeTest".into(),
-        "stPreCompiledContracts2".into(),
-        "stZeroKnowledge2".into(),
-        "stDelegatecallTestHomestead".into(),
-        "stEIP150singleCodeGasPrices".into(),
-        "stCreate2".into(),
-        "stSpecialTest".into(),
-        "stRecursiveCreate".into(),
-        "vmIOandFlowOperations".into(),
-        "stEIP150Specific".into(),
-        "stExtCodeHash".into(),
-        "stCallCodes".into(),
-        "stRandom2".into(),
-        "stMemoryStressTest".into(),
-        "stStaticFlagEnabled".into(),
-        "vmTests".into(),
-        "stZeroKnowledge".into(),
-        "stLogTests".into(),
-        "stBugs".into(),
-        "stEIP1559".into(),
-        "stStaticCall".into(),
-        "stMemExpandingEIP150Calls".into(),
-        "stTransactionTest".into(),
-        "eip3860_initcode".into(),
-        "stCodeCopyTest".into(),
-        "stPreCompiledContracts".into(),
-        "stNonZeroCallsTest".into(),
-        "stMemoryTest".into(),
-        "stRandom".into(),
-        "stInitCodeTest".into(),
-        "stBadOpcode".into(),
-        "eip1153_tstore".into(),
-        "stSolidityTest".into(),
-        "yul".into(),
-        "stEIP3607".into(),
-        "stCreateTest".into(),
-        "eip198_modexp_precompile".into(),
-        "stZeroCallsTest".into(),
-        "stAttackTest".into(),
-        "eip2930_access_list".into(),
-        "stExample".into(),
-        "vmArithmeticTest".into(),
-        "stQuadraticComplexityTest".into(),
-        "stSelfBalance".into(),
-        "stEIP3855-push0".into(),
-        "stWalletTest".into(),
-        "vmLogTest".into(),
-    ])
-}
-
-fn get_ignored_suites() -> HashSet<String> {
-    HashSet::from([
-        "ValueOverflow".into(),      // TODO: parse bigint tx value
-        "ValueOverflowParis".into(), // TODO: parse bigint tx value
-    ])
-}
 
 /// Receives a Bytes object with the hex representation
 /// And returns a Bytes object with the decimal representation
@@ -124,17 +23,6 @@ fn decode_hex(bytes_in_hex: Bytes) -> Option<Bytes> {
 }
 
 fn run_test(path: &Path, contents: String) -> datatest_stable::Result<()> {
-    let group_name = get_group_name_from_path(path);
-
-    if get_ignored_groups().contains(&group_name) {
-        return Ok(());
-    }
-
-    let suite_name = get_suite_name_from_path(path);
-
-    if get_ignored_suites().contains(&suite_name) {
-        return Ok(());
-    }
     let test_suite: TestSuite = serde_json::from_reader(contents.as_bytes())
         .unwrap_or_else(|_| panic!("Failed to parse JSON test {}", path.display()));
 


### PR DESCRIPTION
The changes in this PR aim at improving the observability of the EF tests, by improving the way the tests are run. Main changes include:
1. Change nextest setting so testing doesn't stop at the first failure, running all tests instead, in order to get a consolidated view of the current state.
2. Removal of the ignored tests set, because they were run either way, and marked as success, which is misleading.
3. Separation of each testing group in a separate env variable, so each group of tests has its own summary.